### PR TITLE
144 - Create interactive docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,17 @@ on:
     branches: [ main ]
 
 jobs:
-  build_multi_os:
+  mkdocs-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force
 
+  build_multi_os:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://choosealicense.com/licenses/lgpl-3.0/)
 [![live demo](https://img.shields.io/badge/live%20demo-%E2%86%92-green)](http://ioc-finder.hightower.space/)
 
-Parse [indicators of compromise](https://searchsecurity.techtarget.com/definition/Indicators-of-Compromise-IOC) from text. You can test this project here: [http://ioc-finder.hightower.space/](http://ioc-finder.hightower.space/).
+Parse [indicators of compromise](https://searchsecurity.techtarget.com/definition/Indicators-of-Compromise-IOC) from text. You can explore this library in our [interactive documentation](https://iocs.hightower.space/).
 
 ```python
 from ioc_finder import find_iocs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,13 @@ services:
     <<: *base
     command: ipython
 
+  mkdocs:
+    <<: *base
+    entrypoint: "mkdocs"
+    ports:
+      - "8000:8000"
+    command: ["serve", "--dev-addr=0.0.0.0:8000"]
+
   bump-patch:
     <<: *base
     command: bumpversion patch

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,37 +1,25 @@
 <script type="application/vnd.starboard.nb">
 # %% [markdown]
-
-# Introduction
-
 Welcome to the interactive documentation for the `ioc-finder` package!
 
 Most of the documentation below is interactive to help you learn by experimenting with the package yourself.
 
 > Tip: Press the ▶ Play button on the left (or hit `Shift` + `Enter`) to run a cell's code.
 
-# %% [markdown]
 Run the snippet below to install ioc-finder (it may take 20-30 seconds to install):
 # %% [python]
 import micropip
 micropip.install('ioc-finder')
+print('Done 🎉 - ioc-finder is installed.')
 # %% [markdown]
 Now that we've installed the ioc-finder package, we can use it:
 # %% [python]
 from ioc_finder import find_iocs
+
 text = "Test foobar.com https://example.org/test/bingo.php"
 iocs = find_iocs(text)
 iocs['domains']
 # %% [markdown]
 Does that output make sense? What do you expect from the following code block?
 # %% [python]
-iocs['urls']
-# %% [markdown]
-# API
-
-## ioc_finder.find_iocs()
-
-This function...
-
-# %% [python]
-iocs['urls']
-</script>
+iocs['urls']</script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,37 @@
+<script type="application/vnd.starboard.nb">
+# %% [markdown]
+
+# Introduction
+
+Welcome to the interactive documentation for the `ioc-finder` package!
+
+Most of the documentation below is interactive to help you learn by experimenting with the package yourself.
+
+> Tip: Press the ▶ Play button on the left (or hit `Shift` + `Enter`) to run a cell's code.
+
+# %% [markdown]
+Run the snippet below to install ioc-finder (it may take 20-30 seconds to install):
+# %% [python]
+import micropip
+micropip.install('ioc-finder')
+# %% [markdown]
+Now that we've installed the ioc-finder package, we can use it:
+# %% [python]
+from ioc_finder import find_iocs
+text = "Test foobar.com https://example.org/test/bingo.php"
+iocs = find_iocs(text)
+iocs['domains']
+# %% [markdown]
+Does that output make sense? What do you expect from the following code block?
+# %% [python]
+iocs['urls']
+# %% [markdown]
+# API
+
+## ioc_finder.find_iocs()
+
+This function...
+
+# %% [python]
+iocs['urls']
+</script>

--- a/docs/overrides/base.html
+++ b/docs/overrides/base.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Starboard Notebook</title>
+        <meta name="viewport" content="width=device-width,initial-scale=1">
+        <link href="https://unpkg.com/starboard-notebook@0.6.0/dist/starboard-notebook.css" rel="stylesheet">
+    </head>
+    <body>
+      <!-- Article -->
+      <div class="md-content" data-md-component="content">
+        <article class="md-content__inner md-typeset">
+
+          <!-- Content -->
+          {% block content %}
+
+            <!-- Edit button -->
+            {% if page.edit_url %}
+              <a
+                href="{{ page.edit_url }}"
+                title="{{ lang.t('edit.link.title') }}"
+                class="md-content__button md-icon"
+              >
+                {% include ".icons/material/pencil.svg" %}
+              </a>
+            {% endif %}
+
+            <!--
+              Hack: check whether the content contains a h1 headline. If it
+              doesn't, the page title (or respectively site name) is used
+              as the main headline.
+            -->
+            {% if not "\x3ch1" in page.content %}
+              <h1>{{ page.title | d(config.site_name, true)}}</h1>
+            {% endif %}
+
+            <!-- Markdown content -->
+            {{ page.content }}
+
+            <!-- Last update of source file -->
+            {% if page and page.meta %}
+              {% if page.meta.git_revision_date_localized or
+                    page.meta.revision_date
+              %}
+                {% include "partials/source-file.html" %}
+              {% endif %}
+            {% endif %}
+          {% endblock %}
+        </article>
+      </div>
+
+        <script src="https://unpkg.com/starboard-notebook@0.6.0/dist/starboard-notebook.js"></script>
+    </body>
+</html>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,4 +33,4 @@ markdown_extensions:
   - toc:
       permalink: true
 nav:
-    - Welcome to the Indicator of Compromise (IOC) Finder Documentation!: index.md
+    - Home: index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,36 @@
+site_name: Indicator of Compromise Finder Docs
+site_url: ""
+theme:
+  name: material
+  custom_dir: docs/overrides
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      # toggle:
+      #   icon: material/lightbulb-outline
+      #   name: Switch to dark mode
+      primary: white
+      accent: deep orange
+    # - media: "(prefers-color-scheme: dark)"
+    #   scheme: slate
+    #   toggle:
+    #     icon: material/lightbulb
+    #     name: Switch to light mode
+    #   primary: deep orange
+    #   accent: indigo
+  font: false
+  icon:
+    logo: material/magnify
+  features:
+    - navigation.instant
+    - navigation.top
+    - header.autohide
+    - navigation.tabs
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - meta
+  - toc:
+      permalink: true
+nav:
+    - Welcome to the Indicator of Compromise (IOC) Finder Documentation!: index.md

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,3 +13,4 @@ pytest-benchmark>=3.4.1,<4.0
 pytest-cov>=2.12.1,<3.0
 pytest>=6.2.4,<7.0
 requests>=2.25.1,<3.0
+mkdocs-material==7.1.9


### PR DESCRIPTION
Fixes #144 . I'm adding interactive documentation using [starboard-notebook](https://github.com/gzuidhof/starboard-notebook) (which is a wrapper around [pyodide](https://github.com/pyodide/pyodide)) that is run by [mkdocs](https://www.mkdocs.org/).

Todo:

- [x] Figure out a way to intersperse interactive snippets in with markdown docs handled by mkdocs (this may be an issue fo the future)