### PR TITLE
Perf updates; address some DeprecationWarnings

### DIFF
--- a/ioc_finder/ioc_grammars.py
+++ b/ioc_finder/ioc_grammars.py
@@ -109,7 +109,7 @@ email_address = alphanum_word_start + Combine(
     + Or([domain_name, "[" + ipv4_address + "]", "[IPv6:" + ipv6_address + "]"])("email_address_domain")
 )
 
-url_scheme = one_of(schemes)
+url_scheme = one_of(schemes, caseless=True)
 port = Word(":", nums, min=2)
 url_authority = Combine(Or([complete_email_address, domain_name, ipv4_address, ipv6_address]) + Optional(port)("port"))
 # although the ":" character is not valid in url paths,

--- a/ioc_finder/ioc_grammars.py
+++ b/ioc_finder/ioc_grammars.py
@@ -3,10 +3,12 @@ import re
 
 from pyparsing import (
     CaselessLiteral,
+    Char,
     Combine,
     Empty,
     FollowedBy,
     Literal,
+    MatchFirst,
     NotAny,
     OneOrMore,
     Optional,
@@ -20,6 +22,7 @@ from pyparsing import (
     alphas,
     hexnums,
     nums,
+    one_of,
     printables,
     pyparsing_common,
     replace_with,
@@ -43,8 +46,7 @@ alphanum_word_end = WordEnd(wordChars=alphanums)
 
 # the label definition ignores the fact that labels should not end in an hyphen
 label = Word(initChars=alphanums + "_", bodyChars=alphanums + "-_", max=63)
-tld_literals = (CaselessLiteral(i) for i in tlds)
-domain_tld = Or(tld_literals)
+domain_tld = one_of(tlds, caseless=True)
 domain_name = (
     alphanum_word_start
     + Combine(
@@ -85,13 +87,13 @@ ipv6_address = (
     + ipv6_word_end
 )
 
-complete_email_comment = Combine("(" + Word(alphanums) + ")")
+complete_email_comment = Regex(r"\([a-zA-Z0-9]+\)")
 # the complete_email_local_part grammar ignores the fact that characters like <<<(),:;<>@[\] >>>
 # are possible in a quoted complete_email_local_part
 # (and the double-quotes and backslash should be preceded by a backslash)
 complete_email_local_part = Combine(
     Optional(complete_email_comment)("email_address_start_comment")
-    + OneOrMore(Or([Word(alphanums + "!#$%&'*+-/=?^_`{|}~." + '"'), CaselessLiteral("\\@")]))
+    + OneOrMore(MatchFirst([Word(alphanums + "!#$%&'*+-/=?^_`{|}~." + '"'), CaselessLiteral("\\@")]))
     + Optional(complete_email_comment)("email_address_end_comment")
 )
 complete_email_address = Combine(
@@ -107,14 +109,13 @@ email_address = alphanum_word_start + Combine(
     + Or([domain_name, "[" + ipv4_address + "]", "[IPv6:" + ipv6_address + "]"])("email_address_domain")
 )
 
-scheme_literals = (CaselessLiteral(i) for i in schemes)
-url_scheme = Or(scheme_literals)
-port = Combine(":" + Word(nums))
+url_scheme = one_of(schemes)
+port = Word(":", nums, min=2)
 url_authority = Combine(Or([complete_email_address, domain_name, ipv4_address, ipv6_address]) + Optional(port)("port"))
 # although the ":" character is not valid in url paths,
 # some urls are written with the ":" unencoded so we include it below
 url_path_word = Word(alphanums + "-._~!$&'()*+,;:=%")
-url_path = Combine(OneOrMore(Or([url_path_word, Literal("/")])))
+url_path = Combine(OneOrMore(MatchFirst([url_path_word, Literal("/")])))
 url_query = Word(printables, excludeChars="#\"']")
 url_fragment = Word(printables, excludeChars="?\"']")
 url = alphanum_word_start + Combine(
@@ -223,9 +224,7 @@ root_key_list = [
     "HKEY_PERFORMANCE_DATA",
     "HKEY_DYN_DATA",
 ]
-root_key_literals = (Literal(i) for i in root_key_list)
-
-root_key = Or(root_key_literals)
+root_key = one_of(root_key_list)
 
 
 def hasMultipleConsecutiveSpaces(string):
@@ -282,7 +281,7 @@ google_adsense_publisher_id = (
     alphanum_word_start
     # we use `Or([Literal("pub-")...` instead of something like `CaselessLiteral("pub-")` b/c...
     # we only want to parse "pub" when it is all upper or lowercased (not "pUb" or other, similar variations)
-    + Combine(Or([Literal("pub-"), Literal("PUB-")]) + Word(nums, exact=16)).set_parse_action(
+    + Combine(one_of("pub- PUB-") + Word(nums, exact=16)).set_parse_action(
         pyparsing_common.downcase_tokens
     )
     + alphanum_word_end
@@ -294,7 +293,7 @@ google_analytics_tracker_id = (
     + Combine(
         # we use `Or([Literal("ua-")...` instead of something like `CaselessLiteral("ua-")` b/c...
         # we only want to parse "ua" when it is all upper or lowercased (not "uA" or other, similar variations)
-        Or([Literal("ua-"), Literal("UA-")])
+        one_of("ua- UA-")
         + Word(nums, min=6)("account_number")
         + "-"
         + Word(nums)("property_number")
@@ -306,11 +305,11 @@ google_analytics_tracker_id = (
 # (and https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#segwit-address-format for Bech32 addresses)
 bitcoin_address = (
     alphanum_word_start
-    + Or(
+    + MatchFirst(
         [
-            Combine("1" + Word(alphanums, min=25, max=34)),
-            Combine("3" + Word(alphanums, min=25, max=34)),
-            Combine("bc1" + Word(alphanums, min=11, max=71)),
+            Regex(r"1[a-zA-Z0-9]{25,34}"),
+            Regex(r"3[a-zA-Z0-9]{25,34}"),
+            Regex(r"bc1[a-zA-Z0-9]{11,71}"),
         ]
     )
     + alphanum_word_end
@@ -326,14 +325,14 @@ xmpp_address = alphanum_word_start + Combine(
 # the mac address grammar was developed from https://en.wikipedia.org/wiki/MAC_address#Notational_conventions
 # handles xx:xx:xx:xx:xx:xx or xx-xx-xx-xx-xx-xx
 mac_address_16_bit_section = Combine(
-    (Word(hexnums, exact=2) + Or([Literal("-"), Literal(":")])) * 5 + Word(hexnums, exact=2)
+    (Word(hexnums, exact=2) + one_of("- :")) * 5 + Word(hexnums, exact=2)
 )
 # handles xxxx.xxxx.xxxx
 mac_address_32_bit_section = Combine((Word(hexnums, exact=4) + ".") * 2 + Word(hexnums, exact=4))
 mac_address_word_start = WordStart(wordChars=alphanums + ":-.")
 mac_address_word_end = WordEnd(wordChars=alphanums + ":-.")
 mac_address = (
-    mac_address_word_start + Or([mac_address_16_bit_section, mac_address_32_bit_section]) + mac_address_word_end
+    mac_address_word_start + MatchFirst([mac_address_16_bit_section, mac_address_32_bit_section]) + mac_address_word_end
 )
 
 # the structure of an ssdeep hash is: chunksize:chunk:double_chunk
@@ -360,7 +359,7 @@ user_agent = Combine(
 # https://github.com/fhightower/ioc-finder/issues/13
 file_ending = Word(alphas, max=5)
 windows_file_path = alphanum_word_start + Combine(
-    Word(alphanums, exact=1) + ":" + Word(printables.replace(".", "") + " ") + "." + file_ending
+    Char(alphanums) + ":" + Word(printables + " ", exclude_chars=".") + "." + file_ending
 )
 
 # we need to add '/' and '~' to the alphanum_word_start so that the grammar will match words starting with '/' and '~'
@@ -372,7 +371,7 @@ unix_file_path_wordstart.wordChars.add("/")
 unix_file_path_wordstart.wordChars.add("~")
 
 unix_file_path = unix_file_path_wordstart + Combine(
-    Or([Literal("~"), Literal("/")]) + Word(printables.replace(".", "") + " ") + "." + file_ending
+    one_of("~ /") + Word(printables + " ", exclude_chars=".") + "." + file_ending
 ).addCondition(lambda tokens: "//" not in tokens[0])
 file_path = Or([windows_file_path, unix_file_path]) + alphanum_word_end
 
@@ -396,48 +395,48 @@ pre_attack_tactics_grammar = (
 pre_attack_techniques_grammar = (
     alphanum_word_start
     + Combine(
-        Or([CaselessLiteral(i) for i in pre_attack_techniques]).set_parse_action(pyparsing_common.upcase_tokens)
+        one_of(pre_attack_techniques, caseless=True).set_parse_action(pyparsing_common.upcase_tokens)
         + Optional(attack_sub_technique)
     )
     + alphanum_word_end
 )
 
 enterprise_attack_mitigations_grammar = (
-    alphanum_word_start + Or([CaselessLiteral(i) for i in enterprise_attack_mitigations]) + alphanum_word_end
+    alphanum_word_start + one_of(enterprise_attack_mitigations, caseless=True) + alphanum_word_end
 )
 enterprise_attack_tactics_grammar = (
     alphanum_word_start
-    + Or([CaselessLiteral(i) for i in enterprise_attack_tactics]).set_parse_action(pyparsing_common.upcase_tokens)
+    + one_of(enterprise_attack_tactics, caseless=True).set_parse_action(pyparsing_common.upcase_tokens)
     + alphanum_word_end
 )
 enterprise_attack_techniques_grammar = (
     alphanum_word_start
     + Combine(
-        Or([CaselessLiteral(i) for i in enterprise_attack_techniques]).set_parse_action(pyparsing_common.upcase_tokens)
+        one_of(enterprise_attack_techniques, caseless=True).set_parse_action(pyparsing_common.upcase_tokens)
         + Optional(attack_sub_technique)
+
     )
     + alphanum_word_end
 )
 
 mobile_attack_mitigations_grammar = (
-    alphanum_word_start + Or([CaselessLiteral(i) for i in mobile_attack_mitigations]) + alphanum_word_end
+    alphanum_word_start + one_of(mobile_attack_mitigations, caseless=True) + alphanum_word_end
 )
 mobile_attack_tactics_grammar = (
     alphanum_word_start
-    + Or([CaselessLiteral(i) for i in mobile_attack_tactics]).set_parse_action(pyparsing_common.upcase_tokens)
+    + one_of(mobile_attack_tactics, caseless=True).set_parse_action(pyparsing_common.upcase_tokens)
     + alphanum_word_end
 )
 mobile_attack_techniques_grammar = (
     alphanum_word_start
     + Combine(
-        Or([CaselessLiteral(i) for i in mobile_attack_techniques]).set_parse_action(pyparsing_common.upcase_tokens)
+        one_of(mobile_attack_techniques, caseless=True).set_parse_action(pyparsing_common.upcase_tokens)
         + Optional(attack_sub_technique)
     )
     + alphanum_word_end
 )
 
-tlp_colors_list = [CaselessLiteral("red"), CaselessLiteral("amber"), CaselessLiteral("green"), CaselessLiteral("white")]
-tlp_colors = Or(tlp_colors_list)
+tlp_colors = one_of("red amber green white", caseless=True)
 
 tlp_label = Combine(
     CaselessLiteral("tlp")

--- a/tests/find_iocs_cases/feature__included_ioc_types.py
+++ b/tests/find_iocs_cases/feature__included_ioc_types.py
@@ -28,7 +28,7 @@ IOC_EXAMPLES = {
     ],  # I don't like that the components of an ipv6 can be parsed as an ssdeep... I've ticketed this here: https://github.com/fhightower/ioc-finder/issues/228
     "asns": ["ASN123"],
     "cves": ["CVE-2022-1234"],
-    "registry_key_paths": ["HKEY_LOCAL_MACHINE\Software\Microsoft\Windows"],
+    "registry_key_paths": [r"HKEY_LOCAL_MACHINE\Software\Microsoft\Windows"],
     "google_adsense_publisher_ids": ["pub-1234567891234567"],
     "google_analytics_tracker_ids": ["UA-000000-1"],
     "bitcoin_addresses": ["18ddf28a71089acdbab5038f58044c0a", "3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy"],

--- a/tests/find_iocs_cases/registry_keys.py
+++ b/tests/find_iocs_cases/registry_keys.py
@@ -115,7 +115,7 @@ REGISTRY_DATA = [
         id="registry_14",
     ),
     param(
-        """
+        r"""
         ESET researchers discovered a backdoor linked to malware used by the Stealth Falcon group, an operator of targeted spyware attacks against journalists, activists and dissidents in the Middle East
 
         Stealth Falcon is a threat group, active since 2012, that targets political activists and journalists in the Middle East. It has been tracked by the Citizen Lab (https://citizenlab.ca/about/), a non-profit organization focusing on security and human rights, which published an analysis (https://citizenlab.ca/2016/05/stealth-falcon/) of a particular cyberattack in 2016. In January of 2019, Reuters published an investigative report (https://www.reuters.com/investigates/special-report/usa-spying-raven/) into Project Raven, an initiative allegedly employing former NSA operatives and aiming at the same types of targets as Stealth Falcon.

--- a/tests/test_ioc_finder.py
+++ b/tests/test_ioc_finder.py
@@ -190,12 +190,13 @@ def test_ipv4_cidr_parsing():
 
 
 def test_registry_key_parsing():
-    s = "HKEY_LOCAL_MACHINE\Software\Microsoft\Windows HKLM\Software\Microsoft\Windows HKCC\Software\Microsoft\Windows"
+    s = r"HKEY_LOCAL_MACHINE\Software\Microsoft\Windows HKLM\Software\Microsoft\Windows HKCC\Software\Microsoft\Windows"
     iocs = find_iocs(s)
-    assert len(iocs["registry_key_paths"]) == 3
-    assert "HKEY_LOCAL_MACHINE\Software\Microsoft\Windows" in iocs["registry_key_paths"]
-    assert "HKLM\Software\Microsoft\Windows" in iocs["registry_key_paths"]
-    assert "HKCC\Software\Microsoft\Windows" in iocs["registry_key_paths"]
+    assert sorted([
+        r"HKEY_LOCAL_MACHINE\Software\Microsoft\Windows",
+        r"HKLM\Software\Microsoft\Windows",
+        r"HKCC\Software\Microsoft\Windows",
+    ]) == sorted(iocs["registry_key_paths"])
 
 
 def test_adsense_publisher_id_parsing():


### PR DESCRIPTION
I think I've looked at this project in the past - very nice work! I have some suggestions on pyparsing changes that may speed things up at parse time.  Mostly they consist of changing many instances of code like:

    tld_literals = (CaselessLiteral(i) for i in tlds)
    domain_tld = Or(tld_literals)

to 

    domain_tld = one_of(tlds, caseless=True)

`Or` does exhaustive checking to check all alternatives, even when there is no chance of any overlap. (For instance, there is no need to do `Or([Word(alphas), Word(nums)])`, since there is no possible way that there could be a mistaken match with a shorter version. The time you would need Or is if you had something like `Or([Word(nums), Word(hexnums)])` where "0000ff" needs to parse the full string, so you want Or's behavior of testing *all* alternatives and then choosing the longest match.)

`one_of` is a shortcut for `Or(Literal(x) for x in list_of_strings)` does a couple of things. It will reorder options by length so that short matches don't mask longer ones. It also builds a Regex, for faster matching than MatchFirst.

Other changes are small, fixing DeprecationWarnings mostly.