### PR TITLE
Calculate position on original_text by re.finditer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv/
+.vscode/
 build/
 develop-eggs/
 dist/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
 # IOC Finder
 
+This is a fork of the original IOC Finder project that adds the following functionalities:
+
+- upgrade of the pyparsing library to the version 3.0.7
+- ability to track the position where a particular string has been found.
+
+
+```python
+from ioc_finder import find_iocs
+text = "This is just an example.com https://example.org/test/bingo.php example[.]com example.com T1031"
+iocs, pos_map = find_iocs(text)
+
+for k in iocs.keys():
+    if len(iocs[k]) > 0:
+        print('---------------------')
+        print(k.upper())
+        for el in iocs[k]:
+            print('\t {}:{}'.format(el, pos_map[k][el]))
+
+```
+Below is the original documentation:
+
 [![PyPi](https://img.shields.io/pypi/v/ioc_finder.svg)](https://pypi.python.org/pypi/ioc_finder)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/ioc-finder)
 [![CI](https://github.com/fhightower/ioc-finder/workflows/CI/badge.svg)](https://github.com/fhightower/ioc-finder/actions)

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -7,7 +7,7 @@ from typing import Dict, List
 import click
 import ioc_fanger
 from d8s_strings import string_remove_from_end
-from pyparsing import ParseResults
+from pyparsing import ParseResults, Located
 
 from ioc_finder import ioc_grammars
 
@@ -19,7 +19,18 @@ def _deduplicate(indicator_list: List) -> List:
 
 def _listify(indicator_list: ParseResults) -> List:
     """Convert the multi-dimensional list into a one-dimensional list with empty entries and duplicates removed."""
-    return _deduplicate([indicator[0] for indicator in indicator_list if indicator[0]])
+    #dedup = _deduplicate([indicator[0][1] for indicator in indicator_list if indicator[0]])
+    pos_map = {}
+    to_dedup = []
+    for indicator in indicator_list:
+        if len(indicator) > 0:
+            to_dedup.append(indicator[1][0])
+            if pos_map.get(indicator[1][0]):
+                pos_map[indicator[1][0]].append([indicator[0], indicator[2]])
+            else:
+                pos_map[indicator[1][0]] = [[indicator[0], indicator[2]]]
+
+    return _deduplicate(to_dedup), pos_map
 
 
 def _remove_items(items: List[str], text: str) -> str:
@@ -41,15 +52,17 @@ def prepare_text(text: str) -> str:
 def parse_urls(text: str, *, parse_urls_without_scheme: bool = True) -> List:
     """."""
     if parse_urls_without_scheme:
-        urls = ioc_grammars.scheme_less_url.searchString(text)
+        urls = Located(ioc_grammars.scheme_less_url).searchString(text)
     else:
-        urls = ioc_grammars.url.searchString(text)
-    urls = _listify(urls)
+        urls = Located(ioc_grammars.url).searchString(text)
+    urls, pos_map = _listify(urls)
 
     clean_urls = []
 
     # clean the url
     for url in urls:
+        # save orginal url in order to track its position
+        original_url = url
         # remove `"` and `'` characters from the end of a URL
         url = url.rstrip('"').rstrip("'")
 
@@ -60,12 +73,14 @@ def parse_urls(text: str, *, parse_urls_without_scheme: bool = True) -> List:
         # remove `'/>` and `"/>` from the end of a URL (this character string occurs at the end of an HMTL tag with )
         url = string_remove_from_end(url, '\'/>')
         url = string_remove_from_end(url, '"/>')
-
+        if url != original_url:
+            pos_map[url] = pos_map[original_url]
+            del pos_map[original_url]
         clean_urls.append(url)
 
     # return the cleaned urls...
     # I deduplicate them again because the structure of the URL may have changed when it was cleaned
-    return _deduplicate(clean_urls)
+    return _deduplicate(clean_urls), pos_map
 
 
 def _remove_url_domain_name(urls: List, text) -> str:
@@ -97,117 +112,118 @@ def _percent_decode_url(urls: List, text: str) -> str:
 
 def parse_domain_names(text):
     """."""
-    domains = ioc_grammars.domain_name.searchString(text.lower())
+    domains = Located(ioc_grammars.domain_name).searchString(text.lower())
     return _listify(domains)
 
 
 def parse_ipv4_addresses(text):
     """."""
-    addresses = ioc_grammars.ipv4_address.searchString(text)
+    addresses = Located(ioc_grammars.ipv4_address).searchString(text)
     return _listify(addresses)
 
 
 def parse_ipv6_addresses(text):
     """."""
-    addresses = ioc_grammars.ipv6_address.searchString(text)
+    addresses = Located(ioc_grammars.ipv6_address).searchString(text)
     return _listify(addresses)
 
 
 def parse_complete_email_addresses(text: str) -> List:
     """."""
-    email_addresses = ioc_grammars.complete_email_address.searchString(text)
+    email_addresses = Located(ioc_grammars.complete_email_address).searchString(text)
     return _listify(email_addresses)
 
 
 def parse_email_addresses(text: str) -> List:
     """."""
-    email_addresses = ioc_grammars.email_address.searchString(text)
+    email_addresses = Located(ioc_grammars.email_address).searchString(text)
     return _listify(email_addresses)
 
 
 # there is a trailing underscore on this function to differentiate it from the argument with the same name
 def parse_imphashes_(text: str) -> List:
     """."""
-    full_imphash_instances = ioc_grammars.imphash.searchString(text.lower())
-    full_imphash_instances = _listify(full_imphash_instances)
+    full_imphash_instances = Located(ioc_grammars.imphash).searchString(text.lower())
+    full_imphash_instances, pos_map = _listify(full_imphash_instances)
 
     imphashes = []
 
     for imphash in full_imphash_instances:
         imphashes.append(ioc_grammars.imphash.parseString(imphash).hash[0])
 
-    return imphashes
+    return imphashes, pos_map
 
 
 # there is a trailing underscore on this function to differentiate it from the argument with the same name
 def parse_authentihashes_(text: str) -> List:
     """."""
-    full_authentihash_instances = ioc_grammars.authentihash.searchString(text.lower())
-    full_authentihash_instances = _listify(full_authentihash_instances)
+    full_authentihash_instances = Located(ioc_grammars.authentihash).searchString(text.lower())
+    full_authentihash_instances, pos_map = _listify(full_authentihash_instances)
 
     authentihashes = []
 
     for authentihash in full_authentihash_instances:
         authentihashes.append(ioc_grammars.authentihash.parseString(authentihash).hash[0])
 
-    return authentihashes
+    return authentihashes, pos_map
 
 
 def parse_md5s(text):
     """."""
-    md5s = ioc_grammars.md5.searchString(text)
+    md5s = Located(ioc_grammars.md5).searchString(text)
     return _listify(md5s)
 
 
 def parse_sha1s(text):
     """."""
-    sha1s = ioc_grammars.sha1.searchString(text)
+    sha1s = Located(ioc_grammars.sha1).searchString(text)
     return _listify(sha1s)
 
 
 def parse_sha256s(text):
     """."""
-    sha256s = ioc_grammars.sha256.searchString(text)
+    sha256s = Located(ioc_grammars.sha256).searchString(text)
     return _listify(sha256s)
 
 
 def parse_sha512s(text):
     """."""
-    sha512s = ioc_grammars.sha512.searchString(text)
+    sha512s = Located(ioc_grammars.sha512).searchString(text)
     return _listify(sha512s)
 
 
 def parse_ssdeeps(text):
     """."""
-    ssdeeps = ioc_grammars.ssdeep.searchString(text)
+    ssdeeps = Located(ioc_grammars.ssdeep).searchString(text)
     return _listify(ssdeeps)
 
 
 def parse_asns(text):
     """."""
-    asns = ioc_grammars.asn.searchString(text)
+    asns = Located(ioc_grammars.asn).searchString(text)
     return _listify(asns)
 
 
 def parse_cves(text):
     """."""
-    cves = ioc_grammars.cve.searchString(text)
+    cves = Located(ioc_grammars.cve).searchString(text)
     return _listify(cves)
 
 
 def parse_ipv4_cidrs(text: str) -> List:
     """."""
-    cidrs = ioc_grammars.ipv4_cidr.searchString(text)
+    cidrs = Located(ioc_grammars.ipv4_cidr).searchString(text)
     return _listify(cidrs)
 
 
 def parse_registry_key_paths(text):
     """."""
-    parsed_registry_key_paths = ioc_grammars.registry_key_path.searchString(text)
-    full_parsed_registry_key_paths = _listify(parsed_registry_key_paths)
+    parsed_registry_key_paths = Located(ioc_grammars.registry_key_path).searchString(text)
+    full_parsed_registry_key_paths, pos_map = _listify(parsed_registry_key_paths)
 
     registry_key_paths = []
     for registry_key_path in full_parsed_registry_key_paths:
+        original_registry_key_path = registry_key_path
         # if there is a space in the last section of the parsed registry key path,
         # remove it so that content after a registry key path is not also pulled in...
         # this is a limitation of the grammar:
@@ -216,39 +232,39 @@ def parse_registry_key_paths(text):
             last_section = registry_key_path.split('\\')[-1]
             registry_key_path = registry_key_path.replace(last_section, last_section.split(' ')[0])
             registry_key_paths.append(registry_key_path)
+            pos_map[registry_key_path] = pos_map[original_registry_key_path]
         else:
             registry_key_paths.append(registry_key_path)
-
-    return registry_key_paths
+    return registry_key_paths, pos_map
 
 
 def parse_google_adsense_ids(text):
     """."""
-    adsense_publisher_ids = ioc_grammars.google_adsense_publisher_id.searchString(text)
+    adsense_publisher_ids = Located(ioc_grammars.google_adsense_publisher_id).searchString(text)
     return _listify(adsense_publisher_ids)
 
 
 def parse_google_analytics_ids(text):
     """."""
-    analytics_tracker_ids = ioc_grammars.google_analytics_tracker_id.searchString(text)
+    analytics_tracker_ids = Located(ioc_grammars.google_analytics_tracker_id).searchString(text)
     return _listify(analytics_tracker_ids)
 
 
 def parse_bitcoin_addresses(text):
     """."""
-    bitcoin_addresses = ioc_grammars.bitcoin_address.searchString(text)
+    bitcoin_addresses = Located(ioc_grammars.bitcoin_address).searchString(text)
     return _listify(bitcoin_addresses)
 
 
 def parse_monero_addresses(text):
     """."""
-    monero_addresses = ioc_grammars.monero_address.searchString(text)
+    monero_addresses = Located(ioc_grammars.monero_address).searchString(text)
     return _listify(monero_addresses)
 
 
 def parse_xmpp_addresses(text: str) -> List:
     """."""
-    xmpp_addresses = ioc_grammars.xmpp_address.searchString(text)
+    xmpp_addresses = Located(ioc_grammars.xmpp_address).searchString(text)
     return _listify(xmpp_addresses)
 
 
@@ -262,79 +278,86 @@ def _remove_xmpp_local_part(xmpp_addresses: List, text: str) -> str:
 
 def parse_mac_addresses(text):
     """."""
-    mac_addresses = ioc_grammars.mac_address.searchString(text)
+    mac_addresses = Located(ioc_grammars.mac_address).searchString(text)
     return _listify(mac_addresses)
 
 
 def parse_user_agents(text):
     """."""
-    user_agents = ioc_grammars.user_agent.searchString(text)
+    user_agents = Located(ioc_grammars.user_agent).searchString(text)
     return _listify(user_agents)
 
 
 def parse_file_paths(text):
     """."""
-    file_paths = ioc_grammars.file_path.searchString(text)
+    file_paths = Located(ioc_grammars.file_path).searchString(text)
     return _listify(file_paths)
 
 
 def parse_phone_numbers(text):
     """."""
-    phone_numbers = ioc_grammars.phone_number.searchString(text[::-1])
-    return [phone_number[::-1] for phone_number in _listify(phone_numbers)]
+    phone_numbers = Located(ioc_grammars.phone_number).searchString(text[::-1])
+    list_phone_numbers, pos_map = _listify(phone_numbers)
+
+    clean_list_phone_numbers = []
+    for phone_number in list_phone_numbers:
+        clean_list_phone_numbers.append(phone_number[::-1])
+        pos_map[phone_number[::-1]] = pos_map[phone_number]
+
+    return clean_list_phone_numbers, pos_map
 
 
 def parse_pre_attack_tactics(text):
     """."""
-    data = ioc_grammars.pre_attack_tactics_grammar.searchString(text)
+    data = Located(ioc_grammars.pre_attack_tactics_grammar).searchString(text)
     return _listify(data)
 
 
 def parse_pre_attack_techniques(text):
     """."""
-    data = ioc_grammars.pre_attack_techniques_grammar.searchString(text)
+    data = Located(ioc_grammars.pre_attack_techniques_grammar).searchString(text)
     return _listify(data)
 
 
 def parse_enterprise_attack_mitigations(text):
     """."""
-    data = ioc_grammars.enterprise_attack_mitigations_grammar.searchString(text)
+    data = Located(ioc_grammars.enterprise_attack_mitigations_grammar).searchString(text)
     return _listify(data)
 
 
 def parse_enterprise_attack_tactics(text):
     """."""
-    data = ioc_grammars.enterprise_attack_tactics_grammar.searchString(text)
+    data = Located(ioc_grammars.enterprise_attack_tactics_grammar).searchString(text)
     return _listify(data)
 
 
 def parse_enterprise_attack_techniques(text):
     """."""
-    data = ioc_grammars.enterprise_attack_techniques_grammar.searchString(text)
+    data = Located(ioc_grammars.enterprise_attack_techniques_grammar).searchString(text)
     return _listify(data)
 
 
 def parse_mobile_attack_mitigations(text):
     """."""
-    data = ioc_grammars.mobile_attack_mitigations_grammar.searchString(text)
+    data = Located(ioc_grammars.mobile_attack_mitigations_grammar).searchString(text)
     return _listify(data)
 
 
 def parse_mobile_attack_tactics(text):
     """."""
-    data = ioc_grammars.mobile_attack_tactics_grammar.searchString(text)
+    data = Located(ioc_grammars.mobile_attack_tactics_grammar).searchString(text)
     return _listify(data)
 
 
 def parse_mobile_attack_techniques(text):
     """."""
-    data = ioc_grammars.mobile_attack_techniques_grammar.searchString(text)
+    data = Located(ioc_grammars.mobile_attack_techniques_grammar).searchString(text)
     return _listify(data)
 
 
 def parse_tlp_labels(text):
     """."""
-    tlp_labels = ioc_grammars.tlp_label.searchString(text)
+    tlp_labels = Located(ioc_grammars.tlp_label).searchString(text)
     return _listify(tlp_labels)
 
 
@@ -417,9 +440,9 @@ def find_iocs(  # noqa: CCR001 pylint: disable=R0912,R0915
     text = prepare_text(text)
     # keep a copy of the original text - some items should be parsed from the original text
     original_text = text
-
+    pos_map = {}
     # urls
-    iocs['urls'] = parse_urls(text, parse_urls_without_scheme=parse_urls_without_scheme)
+    iocs['urls'], pos_map['urls'] = parse_urls(text, parse_urls_without_scheme=parse_urls_without_scheme)
     if not parse_domain_from_url and not parse_from_url_path:
         text = _remove_items(iocs['urls'], text)
     elif not parse_domain_from_url:
@@ -432,7 +455,7 @@ def find_iocs(  # noqa: CCR001 pylint: disable=R0912,R0915
         text = _percent_decode_url(iocs['urls'], text)
 
     # xmpp addresses
-    iocs['xmpp_addresses'] = parse_xmpp_addresses(text)
+    iocs['xmpp_addresses'], pos_map['xmpp_addresses'] = parse_xmpp_addresses(text)
     if not parse_domain_name_from_xmpp_address:
         text = _remove_items(iocs['xmpp_addresses'], text)
     # even if we want to parse domain names from the xmpp_address,
@@ -441,9 +464,9 @@ def find_iocs(  # noqa: CCR001 pylint: disable=R0912,R0915
         text = _remove_xmpp_local_part(iocs['xmpp_addresses'], text)
 
     # complete email addresses
-    iocs['email_addresses_complete'] = parse_complete_email_addresses(text)
+    iocs['email_addresses_complete'], pos_map['email_addresses_complete'] = parse_complete_email_addresses(text)
     # simple email addresses
-    iocs['email_addresses'] = parse_email_addresses(text)
+    iocs['email_addresses'], pos_map['email_addresses'] = parse_email_addresses(text)
     if not parse_domain_from_email_address:
         text = _remove_items(iocs['email_addresses_complete'], text)
         text = _remove_items(iocs['email_addresses'], text)
@@ -452,7 +475,7 @@ def find_iocs(  # noqa: CCR001 pylint: disable=R0912,R0915
     text = _remove_items(['[IPv6:'], text)
 
     # cidr ranges
-    iocs['ipv4_cidrs'] = parse_ipv4_cidrs(text)
+    iocs['ipv4_cidrs'], pos_map['email_addresses'] = parse_ipv4_cidrs(text)
     if not parse_address_from_cidr:
         text = _remove_items(iocs['ipv4_cidrs'], text)
 
@@ -464,61 +487,75 @@ def find_iocs(  # noqa: CCR001 pylint: disable=R0912,R0915
 
     # file hashes
     if parse_imphashes:
-        iocs['imphashes'] = parse_imphashes_(text)
+        iocs['imphashes'], pos_map['imphashes'] = parse_imphashes_(text)
         # remove the imphashes so they are not also parsed as md5s
         text = _remove_items(iocs['imphashes'], text)
 
     if parse_authentihashes:
-        iocs['authentihashes'] = parse_authentihashes_(text)
+        iocs['authentihashes'], pos_map['authentihashes'] = parse_authentihashes_(text)
         # remove the authentihashes so they are not also parsed as sha256s
         text = _remove_items(iocs['authentihashes'], text)
 
     # domains
-    iocs['domains'] = parse_domain_names(text)
+    iocs['domains'], pos_map['domains'] = parse_domain_names(text)
 
     # ip addresses
-    iocs['ipv4s'] = parse_ipv4_addresses(text)
-    iocs['ipv6s'] = parse_ipv6_addresses(text)
+    iocs['ipv4s'], pos_map['ipv4s'] = parse_ipv4_addresses(text)
+    iocs['ipv6s'], pos_map['ipv6s'] = parse_ipv6_addresses(text)
 
     # file hashes
-    iocs['sha512s'] = parse_sha512s(text)
-    iocs['sha256s'] = parse_sha256s(text)
-    iocs['sha1s'] = parse_sha1s(text)
-    iocs['md5s'] = parse_md5s(text)
-    iocs['ssdeeps'] = parse_ssdeeps(text)
+    iocs['sha512s'], pos_map['sha512s'] = parse_sha512s(text)
+    iocs['sha256s'], pos_map['sha256s'] = parse_sha256s(text)
+    iocs['sha1s'], pos_map['sha1s'] = parse_sha1s(text)
+    iocs['md5s'], pos_map['md5s'] = parse_md5s(text)
+    iocs['ssdeeps'], pos_map['ssdeeps'] = parse_ssdeeps(text)
 
     # misc
-    iocs['asns'] = parse_asns(text)
-    iocs['cves'] = parse_cves(original_text)
-    iocs['registry_key_paths'] = parse_registry_key_paths(text)
-    iocs['google_adsense_publisher_ids'] = parse_google_adsense_ids(text)
-    iocs['google_analytics_tracker_ids'] = parse_google_analytics_ids(text)
-    iocs['bitcoin_addresses'] = parse_bitcoin_addresses(text)
-    iocs['monero_addresses'] = parse_monero_addresses(text)
-    iocs['mac_addresses'] = parse_mac_addresses(text)
-    iocs['user_agents'] = parse_user_agents(text)
-    iocs['phone_numbers'] = parse_phone_numbers(text)
-    iocs['tlp_labels'] = parse_tlp_labels(original_text)
+    iocs['asns'], pos_map['asns'] = parse_asns(text)
+    iocs['cves'], pos_map['cves'] = parse_cves(original_text)
+    iocs['registry_key_paths'], pos_map['registry_key_paths'] = parse_registry_key_paths(text)
+    iocs['google_adsense_publisher_ids'], pos_map['google_adsense_publisher_ids'] = parse_google_adsense_ids(text)
+    iocs['google_analytics_tracker_ids'], pos_map['google_analytics_tracker_ids'] = parse_google_analytics_ids(text)
+    iocs['bitcoin_addresses'], pos_map['bitcoin_addresses'] = parse_bitcoin_addresses(text)
+    iocs['monero_addresses'], pos_map['monero_addresses'] = parse_monero_addresses(text)
+    iocs['mac_addresses'], pos_map['mac_addresses'] = parse_mac_addresses(text)
+    iocs['user_agents'], pos_map['user_agents'] = parse_user_agents(text)
+    iocs['phone_numbers'], pos_map['phone_numbers'] = parse_phone_numbers(text)
+    iocs['tlp_labels'], pos_map['tlp_labels'] = parse_tlp_labels(original_text)
+
+    # Da sistemare
+    pos_map['attack_mitigations'] = {}
+    pos_map['attack_tactics'] = {}
+    pos_map['attack_techniques'] = {}
+
+    am_enterprise, pos_map['attack_mitigations']['enterprise'] = parse_enterprise_attack_mitigations(original_text)
+    am_mobile, pos_map['attack_mitigations']['mobile'] = parse_mobile_attack_mitigations(original_text)
+    ata_pre_attack, pos_map['attack_tactics']['pre_attack'] = parse_pre_attack_tactics(original_text)
+    ata_enterprise, pos_map['attack_tactics']['enterprise'] = parse_enterprise_attack_tactics(original_text)
+    ata_mobile, pos_map['attack_tactics']['mobile'] = parse_mobile_attack_tactics(original_text)
+    ate_pre_attack, pos_map['attack_techniques']['pre_attack'] = parse_pre_attack_techniques(original_text)
+    ate_enterprise, pos_map['attack_techniques']['enterprise'] = parse_enterprise_attack_techniques(original_text)
+    ate_mobile, pos_map['attack_techniques']['mobile'] = parse_mobile_attack_techniques(original_text)
 
     iocs['attack_mitigations'] = {  # type: ignore
-        "enterprise": parse_enterprise_attack_mitigations(original_text),
-        "mobile": parse_mobile_attack_mitigations(original_text),
+        "enterprise": am_enterprise,
+        "mobile": am_mobile,
     }
     iocs['attack_tactics'] = {  # type: ignore
-        "pre_attack": parse_pre_attack_tactics(original_text),
-        "enterprise": parse_enterprise_attack_tactics(original_text),
-        "mobile": parse_mobile_attack_tactics(original_text),
+        "pre_attack": ata_pre_attack,
+        "enterprise": ata_enterprise,
+        "mobile": ata_mobile,
     }
     iocs['attack_techniques'] = {  # type: ignore
-        "pre_attack": parse_pre_attack_techniques(original_text),
-        "enterprise": parse_enterprise_attack_techniques(original_text),
-        "mobile": parse_mobile_attack_techniques(original_text),
+        "pre_attack": ate_pre_attack,
+        "enterprise": ate_enterprise,
+        "mobile": ate_mobile,
     }
 
     # if there are still url paths in the text, remove them so they don't get parsed as file names
     if parse_from_url_path:
         text = _remove_url_paths(iocs['urls'], text)
 
-    iocs['file_paths'] = parse_file_paths(text)
+    iocs['file_paths'], pos_map['file_paths'] = parse_file_paths(text)
 
-    return iocs
+    return iocs, pos_map

--- a/ioc_finder/ioc_grammars.py
+++ b/ioc_finder/ioc_grammars.py
@@ -18,13 +18,15 @@ from pyparsing import (
     ZeroOrMore,
     alphanums,
     alphas,
-    downcaseTokens,
     hexnums,
     nums,
     printables,
     replaceWith,
-    upcaseTokens,
 )
+
+from pyparsing import common
+
+
 
 from ioc_finder.data import (
     enterprise_attack_mitigations,
@@ -51,7 +53,7 @@ domain_name = (
         Combine(OneOrMore(label + ('.' + FollowedBy(Word(alphanums + '-_')))))('domain_labels') + domain_tld('tld')
     )
     + alphanum_word_end
-).setParseAction(downcaseTokens)
+).setParseAction(common.downcaseTokens)
 
 ipv4_section = (
     Word(nums, asKeyword=True, max=3)
@@ -100,7 +102,7 @@ complete_email_address = Combine(
     + Or([domain_name, '[' + ipv4_address + ']', '[IPv6:' + ipv6_address + ']'])('email_address_domain')
 )
 
-email_local_part = Word(alphanums, bodyChars=alphanums + "+-_.").setParseAction(downcaseTokens)
+email_local_part = Word(alphanums, bodyChars=alphanums + "+-_.").setParseAction(common.downcaseTokens)
 email_address = alphanum_word_start + Combine(
     email_local_part('email_address_local_part')
     + "@"
@@ -141,20 +143,20 @@ scheme_less_url = alphanum_word_start + Combine(
 # this allows for matching file hashes preceeded with an 'x' or 'X'...
 # see https://github.com/fhightower/ioc-finder/issues/41
 file_hash_word_start = WordStart(wordChars=alphanums.replace('x', '').replace('X', ''))
-md5 = file_hash_word_start + Word(hexnums, exact=32).setParseAction(downcaseTokens) + alphanum_word_end
+md5 = file_hash_word_start + Word(hexnums, exact=32).setParseAction(common.downcaseTokens) + alphanum_word_end
 imphash = Combine(
     Or(['imphash', 'import hash']) + Optional(Word(printables, excludeChars=alphanums)) + md5('hash'),
     joinString=' ',
     adjacent=False,
 )
-sha1 = file_hash_word_start + Word(hexnums, exact=40).setParseAction(downcaseTokens) + alphanum_word_end
-sha256 = file_hash_word_start + Word(hexnums, exact=64).setParseAction(downcaseTokens) + alphanum_word_end
+sha1 = file_hash_word_start + Word(hexnums, exact=40).setParseAction(common.downcaseTokens) + alphanum_word_end
+sha256 = file_hash_word_start + Word(hexnums, exact=64).setParseAction(common.downcaseTokens) + alphanum_word_end
 authentihash = Combine(
     Or(['authentihash']) + Optional(Word(printables, excludeChars=alphanums)) + sha256('hash'),
     joinString=' ',
     adjacent=False,
 )
-sha512 = file_hash_word_start + Word(hexnums, exact=128).setParseAction(downcaseTokens) + alphanum_word_end
+sha512 = file_hash_word_start + Word(hexnums, exact=128).setParseAction(common.downcaseTokens) + alphanum_word_end
 
 year = Word('12') + Word(nums, exact=3)
 cve = (
@@ -260,7 +262,7 @@ registry_key_path = (
 # see https://support.google.com/adsense/answer/2923881?hl=en
 google_adsense_publisher_id = (
     alphanum_word_start
-    + Combine(Or(['pub-', 'PUB-']) + Word(nums, exact=16)).setParseAction(downcaseTokens)
+    + Combine(Or(['pub-', 'PUB-']) + Word(nums, exact=16)).setParseAction(common.downcaseTokens)
     + alphanum_word_end
 )
 
@@ -269,7 +271,7 @@ google_analytics_tracker_id = (
     alphanum_word_start
     + Combine(
         Or(['UA-', 'ua-']) + Word(nums, min=6)('account_number') + '-' + Word(nums)('property_number')
-    ).setParseAction(upcaseTokens)
+    ).setParseAction(common.upcaseTokens)
     + alphanum_word_end
 )
 
@@ -359,13 +361,13 @@ phone_number = Or([phone_number_format_1])
 attack_sub_technique = Literal('.') + Word(nums, exact=3)
 pre_attack_tactics_grammar = (
     alphanum_word_start
-    + Or([CaselessLiteral(i) for i in pre_attack_tactics]).setParseAction(upcaseTokens)
+    + Or([CaselessLiteral(i) for i in pre_attack_tactics]).setParseAction(common.upcaseTokens)
     + alphanum_word_end
 )
 pre_attack_techniques_grammar = (
     alphanum_word_start
     + Combine(
-        Or([CaselessLiteral(i) for i in pre_attack_techniques]).setParseAction(upcaseTokens)
+        Or([CaselessLiteral(i) for i in pre_attack_techniques]).setParseAction(common.upcaseTokens)
         + Optional(attack_sub_technique)
     )
     + alphanum_word_end
@@ -376,13 +378,13 @@ enterprise_attack_mitigations_grammar = (
 )
 enterprise_attack_tactics_grammar = (
     alphanum_word_start
-    + Or([CaselessLiteral(i) for i in enterprise_attack_tactics]).setParseAction(upcaseTokens)
+    + Or([CaselessLiteral(i) for i in enterprise_attack_tactics]).setParseAction(common.upcaseTokens)
     + alphanum_word_end
 )
 enterprise_attack_techniques_grammar = (
     alphanum_word_start
     + Combine(
-        Or([CaselessLiteral(i) for i in enterprise_attack_techniques]).setParseAction(upcaseTokens)
+        Or([CaselessLiteral(i) for i in enterprise_attack_techniques]).setParseAction(common.upcaseTokens)
         + Optional(attack_sub_technique)
     )
     + alphanum_word_end
@@ -393,13 +395,13 @@ mobile_attack_mitigations_grammar = (
 )
 mobile_attack_tactics_grammar = (
     alphanum_word_start
-    + Or([CaselessLiteral(i) for i in mobile_attack_tactics]).setParseAction(upcaseTokens)
+    + Or([CaselessLiteral(i) for i in mobile_attack_tactics]).setParseAction(common.upcaseTokens)
     + alphanum_word_end
 )
 mobile_attack_techniques_grammar = (
     alphanum_word_start
     + Combine(
-        Or([CaselessLiteral(i) for i in mobile_attack_techniques]).setParseAction(upcaseTokens)
+        Or([CaselessLiteral(i) for i in mobile_attack_techniques]).setParseAction(common.upcaseTokens)
         + Optional(attack_sub_technique)
     )
     + alphanum_word_end
@@ -412,4 +414,4 @@ tlp_label = Combine(
     CaselessLiteral('tlp')
     + Or([Literal(':'), Literal('-'), Literal(' '), Empty()]).setParseAction(lambda x: ':')
     + tlp_colors
-).setParseAction(upcaseTokens)
+).setParseAction(common.upcaseTokens)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click>=7.1.2,<9.0
 ioc-fanger>=3.0,<4.0
-pyparsing>=2.4.7,<3.0
+pyparsing==3.0.7
 d8s-strings>=0.5.0,<1.0

--- a/test.py
+++ b/test.py
@@ -1,0 +1,12 @@
+from ioc_finder import find_iocs
+text = "This is just an example.com https://example.org/test/bingo.php example[.]com example.com T1031"
+iocs, pos_map = find_iocs(text)
+#print('Domains: {}'.format(iocs['domains']))
+#print('URLs: {}'.format(iocs['urls']))
+
+for k in iocs.keys():
+    if len(iocs[k]) > 0:
+        print('---------------------')
+        print(k.upper())
+        for el in iocs[k]:
+            print('\t {}:{}'.format(el, pos_map[k][el]))


### PR DESCRIPTION
Located handling that calculates the position on often already cleaned-up text is removed, in favor of the re.finditer function that takes the original_text as a parameter.
Also removed is the prepare_text that is called when preprocessing.
