### PR TITLE
feat(urls): provide two collections of urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [8.0.0] - UNRELEASED
+
+### Changed
+
+- The content formally returned in the `urls` key is now returned in the `urls_complete` key and the `urls` key now returns a subset of the `urls_complete` data - removing technically valid URLs
+which are unliklely to be found in the wild
+    - e.g. `https://example.com/abc,False,False` is a valid URL per the [RFC](https://www.rfc-editor.org/rfc/rfc3986#section-3.3), but it unlikely that this is *actually* a URL actively being used
+    - Given `https://example.com/abc,False,False` as input, `ioc_finder.find_iocs("https://example.com/abc,False,False")` will return:
+
+    ```python
+    {
+        ...
+        "urls": [],
+        "urls_complete": ["https://example.com/abc,False,False"],
+        ...
+    }
+    ```
+
+### Added
+
+- The `urls_complete` key (see the previous bullet point for more details)
+
 ## [7.3.0] - UNRELEASED
 
 ### Changed

--- a/tests/find_iocs_cases/urls.py
+++ b/tests/find_iocs_cases/urls.py
@@ -34,4 +34,15 @@ URL_DATA = [
         {"parse_domain_from_url": False},
         id="Consecutive slashes handled properly",
     ),
+    param(
+        "www.example.com/abc,False,False",
+        {
+            "urls": [],
+            "urls_complete": ["www.example.com/abc,False,False"],
+            "domains": ["example.com"],
+        },
+        {},
+        id="Complete URLs parsed when urls are not",
+    ),
 ]
+


### PR DESCRIPTION
Move the data currently captured in `urls` to `urls_complete` and populate `urls` with 'simple' URLs which are likely to be used in the wild and identified as such by humans.

Fixes #261 