### PR TITLE
Improve attack grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### Changed
-
 ## [8.1.0] - 2026.04.25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- The enterprise/mobile/pre-attack mitigation, tactic, and technique parsers now use a regex pre-filter to identify candidate ATT&CK-ID spans before running the grammar, significantly improving performance on large inputs ([#238](https://github.com/fhightower/ioc-finder/issues/238))
+
 ## [8.0.2] - 2026.04.23
 
 ### Deprecated

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -392,16 +392,12 @@ def _scan_attack_candidates(text, candidate_re, grammar):
 
 def parse_pre_attack_tactics(text):
     """."""
-    return _scan_attack_candidates(
-        text, _ATTACK_TACTIC_CANDIDATE_RE, ioc_grammars.pre_attack_tactics_grammar
-    )
+    return _scan_attack_candidates(text, _ATTACK_TACTIC_CANDIDATE_RE, ioc_grammars.pre_attack_tactics_grammar)
 
 
 def parse_pre_attack_techniques(text):
     """."""
-    return _scan_attack_candidates(
-        text, _ATTACK_TECHNIQUE_CANDIDATE_RE, ioc_grammars.pre_attack_techniques_grammar
-    )
+    return _scan_attack_candidates(text, _ATTACK_TECHNIQUE_CANDIDATE_RE, ioc_grammars.pre_attack_techniques_grammar)
 
 
 def parse_enterprise_attack_mitigations(text):
@@ -413,9 +409,7 @@ def parse_enterprise_attack_mitigations(text):
 
 def parse_enterprise_attack_tactics(text):
     """."""
-    return _scan_attack_candidates(
-        text, _ATTACK_TACTIC_CANDIDATE_RE, ioc_grammars.enterprise_attack_tactics_grammar
-    )
+    return _scan_attack_candidates(text, _ATTACK_TACTIC_CANDIDATE_RE, ioc_grammars.enterprise_attack_tactics_grammar)
 
 
 def parse_enterprise_attack_techniques(text):
@@ -434,16 +428,12 @@ def parse_mobile_attack_mitigations(text):
 
 def parse_mobile_attack_tactics(text):
     """."""
-    return _scan_attack_candidates(
-        text, _ATTACK_TACTIC_CANDIDATE_RE, ioc_grammars.mobile_attack_tactics_grammar
-    )
+    return _scan_attack_candidates(text, _ATTACK_TACTIC_CANDIDATE_RE, ioc_grammars.mobile_attack_tactics_grammar)
 
 
 def parse_mobile_attack_techniques(text):
     """."""
-    return _scan_attack_candidates(
-        text, _ATTACK_TECHNIQUE_CANDIDATE_RE, ioc_grammars.mobile_attack_techniques_grammar
-    )
+    return _scan_attack_candidates(text, _ATTACK_TECHNIQUE_CANDIDATE_RE, ioc_grammars.mobile_attack_techniques_grammar)
 
 
 def parse_tlp_labels(text):

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -1,6 +1,7 @@
 """Python package for finding observables in text."""
 
 import json
+import re
 import urllib.parse as urlparse
 import warnings
 from collections.abc import Callable, Iterable, Mapping
@@ -10,6 +11,19 @@ import ioc_fanger
 from pyparsing import ParseException, ParseResults
 
 from ioc_finder import ioc_grammars
+
+# Cheap regexes used to locate ATT&CK-ID-shaped candidate spans so the
+# pyparsing grammars (which carry alternations of hundreds of literal IDs)
+# only run where a match could plausibly occur rather than at every offset.
+# The leading lookbehind mirrors ioc_grammars.alphanum_word_start, which only
+# treats ASCII alphanumerics as word chars. Trailing char classes greedily
+# consume any remaining alphanumerics (and dots, for techniques with
+# sub-technique suffixes) so the grammar is handed the full token and can
+# apply its own word-end check — e.g. "T1156.0012" must reach the grammar
+# intact so it can be correctly rejected rather than truncated to "T1156".
+_ATTACK_MITIGATION_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9])M\d{4}[A-Za-z0-9]*", re.IGNORECASE)
+_ATTACK_TACTIC_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9])TA\d{4}[A-Za-z0-9]*", re.IGNORECASE)
+_ATTACK_TECHNIQUE_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9])T\d{4}[A-Za-z0-9.]*", re.IGNORECASE)
 
 _DEPRECATED_KWARG_SENTINEL = object()
 
@@ -362,52 +376,74 @@ def parse_file_paths(text):
     return _listify(file_paths)
 
 
+def _scan_attack_candidates(text, candidate_re, grammar):
+    # Pre-filtering with a cheap regex avoids running the large one_of(...)
+    # alternation inside the grammar at every offset of the text.
+    seen: set[str] = set()
+    out: list[str] = []
+    for m in candidate_re.finditer(text):
+        for tokens, _start, _end in grammar.scanString(m.group(0)):
+            value = tokens[0]
+            if value and value not in seen:
+                seen.add(value)
+                out.append(value)
+    return out
+
+
 def parse_pre_attack_tactics(text):
     """."""
-    data = ioc_grammars.pre_attack_tactics_grammar.searchString(text)
-    return _listify(data)
+    return _scan_attack_candidates(
+        text, _ATTACK_TACTIC_CANDIDATE_RE, ioc_grammars.pre_attack_tactics_grammar
+    )
 
 
 def parse_pre_attack_techniques(text):
     """."""
-    data = ioc_grammars.pre_attack_techniques_grammar.searchString(text)
-    return _listify(data)
+    return _scan_attack_candidates(
+        text, _ATTACK_TECHNIQUE_CANDIDATE_RE, ioc_grammars.pre_attack_techniques_grammar
+    )
 
 
 def parse_enterprise_attack_mitigations(text):
     """."""
-    data = ioc_grammars.enterprise_attack_mitigations_grammar.searchString(text)
-    return _listify(data)
+    return _scan_attack_candidates(
+        text, _ATTACK_MITIGATION_CANDIDATE_RE, ioc_grammars.enterprise_attack_mitigations_grammar
+    )
 
 
 def parse_enterprise_attack_tactics(text):
     """."""
-    data = ioc_grammars.enterprise_attack_tactics_grammar.searchString(text)
-    return _listify(data)
+    return _scan_attack_candidates(
+        text, _ATTACK_TACTIC_CANDIDATE_RE, ioc_grammars.enterprise_attack_tactics_grammar
+    )
 
 
 def parse_enterprise_attack_techniques(text):
     """."""
-    data = ioc_grammars.enterprise_attack_techniques_grammar.searchString(text)
-    return _listify(data)
+    return _scan_attack_candidates(
+        text, _ATTACK_TECHNIQUE_CANDIDATE_RE, ioc_grammars.enterprise_attack_techniques_grammar
+    )
 
 
 def parse_mobile_attack_mitigations(text):
     """."""
-    data = ioc_grammars.mobile_attack_mitigations_grammar.searchString(text)
-    return _listify(data)
+    return _scan_attack_candidates(
+        text, _ATTACK_MITIGATION_CANDIDATE_RE, ioc_grammars.mobile_attack_mitigations_grammar
+    )
 
 
 def parse_mobile_attack_tactics(text):
     """."""
-    data = ioc_grammars.mobile_attack_tactics_grammar.searchString(text)
-    return _listify(data)
+    return _scan_attack_candidates(
+        text, _ATTACK_TACTIC_CANDIDATE_RE, ioc_grammars.mobile_attack_tactics_grammar
+    )
 
 
 def parse_mobile_attack_techniques(text):
     """."""
-    data = ioc_grammars.mobile_attack_techniques_grammar.searchString(text)
-    return _listify(data)
+    return _scan_attack_candidates(
+        text, _ATTACK_TECHNIQUE_CANDIDATE_RE, ioc_grammars.mobile_attack_techniques_grammar
+    )
 
 
 def parse_tlp_labels(text):

--- a/tests/find_iocs_cases/attack_data.py
+++ b/tests/find_iocs_cases/attack_data.py
@@ -70,4 +70,12 @@ ATTACK_DATA = [
     ),
     param("T1546.004", {"attack_techniques": {"enterprise": ["T1546.004"]}}, {}, id="attack_pattern_15"),
     param("T1156.0012", {}, {}, id="attack_pattern_16"),
+    param("T1156.001", {"attack_techniques": {"enterprise": ["T1156.001"]}}, {}, id="attack_pattern_17"),
+    param("foo T1156.0012 bar", {}, {}, id="attack_pattern_18"),
+    param(
+        "foo T1156.001 bar T1156.0012 baz",
+        {"attack_techniques": {"enterprise": ["T1156.001"]}},
+        {},
+        id="attack_pattern_19",
+    ),
 ]


### PR DESCRIPTION
Fixes #238 .

  | Function | Before | After | Speedup |                                                                              
  | --- | --- | --- | --- |                                                                                            
  | `parse_enterprise_attack_techniques` | 81 ms | 24 ms | 3.4× |                                                      
  | `parse_enterprise_attack_mitigations` | 67 ms | 5 ms | 13× |                                                       
  | `parse_enterprise_attack_tactics` | 66 ms | 5 ms | 12× |                                                           
  | `parse_mobile_attack_techniques` | 118 ms | 17 ms | 7× |                                                           
  | `parse_mobile_attack_mitigations` | 211 ms | 5 ms | 43× |                                                          
  | `parse_mobile_attack_tactics` | 156 ms | 5 ms | 30× |                                                              
  | `parse_pre_attack_techniques` | 94 ms | 20 ms | 4.6× |                                                             
  | `parse_pre_attack_tactics` | 339 ms | 9 ms | 40× |