### PR TITLE
Allow '@' in url_complete paths (RFC 3986 pchar)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- `urls_complete` now accepts `@` in URL paths, matching the RFC 3986 `pchar` definition (e.g. `https://example.com/users/@alice` is now captured in full).
+
 ## [9.2.0] - 2026.04.30
 
 ### Added

--- a/ioc_finder/ioc_grammars.py
+++ b/ioc_finder/ioc_grammars.py
@@ -118,12 +118,13 @@ url_authority_complete = Combine(
     + Or([domain_name, ipv4_address, ipv6_address])("url_host")
     + Optional(port)("port")
 )
-# The url_path_word characters are taken from https://www.ietf.org/rfc/rfc3986.txt...
-# (of particular interest is "Appendix A.  Collected ABNF for URI")
-# Although the ":" character is not valid in url paths,
-# some urls are written with the ":" unencoded so we include it below
+# The url_path_word characters are taken from https://www.ietf.org/rfc/rfc3986.txt
+# (of particular interest is "Appendix A.  Collected ABNF for URI", which defines
+# pchar = unreserved / pct-encoded / sub-delims / ":" / "@").
+# url_path_word omits "," and "@" to reduce false positives in the simple grammar;
+# url_path_word_complete includes the full pchar set for spec-faithful matching.
 url_path_word = Word(alphanums + "-._~!$&'()*+;=:%")
-url_path_word_complete = Word(alphanums + "-._~!$&'()*+,;=:%")
+url_path_word_complete = Word(alphanums + "-._~!$&'()*+,;=:@%")
 url_path = Combine(OneOrMore(MatchFirst([url_path_word, Literal("/")])))
 url_path_complete = Combine(OneOrMore(MatchFirst([url_path_word_complete, Literal("/")])))
 url_query = Word(printables, exclude_chars="#\"']")

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -177,6 +177,27 @@ def test_parse_domain_from_url__userinfo_url():
     assert result["domains"] == []
 
 
+def test_urls_complete__at_sign_in_path():
+    """The complete URL grammar should accept "@" in the path per RFC 3986 pchar."""
+    result = find_iocs(
+        "Check https://example.com/users/@alice for details",
+        parse_urls_without_scheme=False,
+    )
+    assert result["urls_complete"] == ["https://example.com/users/@alice"]
+
+    result = find_iocs(
+        "https://api.example.com/v1/@user/profile.json and https://gitlab.com/group/proj/-/issues/@me",
+        parse_urls_without_scheme=False,
+    )
+    assert iterables_have_same_items(
+        result["urls_complete"],
+        [
+            "https://api.example.com/v1/@user/profile.json",
+            "https://gitlab.com/group/proj/-/issues/@me",
+        ],
+    )
+
+
 def test_issue_104__encoded_url_properly_parsed():
     s = "https://asf.goole.com/mail?url=http%3A%2F%2Ffreasdfuewriter.com%2Fcs%2Fimage%2FCommerciaE.jpg&t=1575955624&ymreqid=733bc9eb-e8f-34cb-1cb5-120010019e00&sig=x2Pa2oOYxanG52s4vyCEFg--~Chttp://uniddloos.zddfdd.org/CBA0019_file_00002_pdf.zip"
     result = find_iocs(s)


### PR DESCRIPTION
## Summary
- `url_path_word_complete` now includes `@`, matching RFC 3986 `pchar`. URLs like `https://example.com/users/@alice` are captured in full by `urls_complete` instead of being truncated at `/users/`.
- Updated the comment at `ioc_grammars.py:121-125` to accurately describe the spec (the previous comment incorrectly stated that `:` is invalid in URL paths).
- Added a regression test in `tests/test_urls.py`.

## Test plan
- [x] `uv run pytest` — 207 passed
- [x] Confirmed new test fails on the pre-fix grammar and passes after the fix