### PR TITLE
Add x509_certificate and artifact IOC types (closes #299)

### DIFF
--- a/ioc_finder/__init__.py
+++ b/ioc_finder/__init__.py
@@ -6,6 +6,7 @@ from .ioc_finder import (
     DEFAULT_IOC_TYPES,
     SUPPORTED_IOC_TYPES,
     find_iocs,
+    parse_artifacts,
     parse_asns,
     parse_authentihashes_,
     parse_bitcoin_addresses,
@@ -36,6 +37,7 @@ from .ioc_finder import (
     parse_tlp_labels,
     parse_urls,
     parse_user_agents,
+    parse_x509_certificates,
     parse_xmpp_addresses,
     prepare_text,
 )
@@ -50,6 +52,7 @@ __all__ = [
     "DEFAULT_IOC_TYPES",
     "SUPPORTED_IOC_TYPES",
     "find_iocs",
+    "parse_artifacts",
     "parse_asns",
     "parse_authentihashes_",
     "parse_bitcoin_addresses",
@@ -80,6 +83,7 @@ __all__ = [
     "parse_tlp_labels",
     "parse_urls",
     "parse_user_agents",
+    "parse_x509_certificates",
     "parse_xmpp_addresses",
     "prepare_text",
 ]

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -234,6 +234,25 @@ _MONERO_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9])4[0-9AB][1-9A-HJ-NP-Za-km-z]
 # spaces/tabs (the grammar's body word matches multi-space runs too, e.g.
 # "C:\Program  Files\app.exe"). Newlines are excluded from inter-token
 # separators because the grammar's printables don't include them.
+# PEM-encoded X.509 certificate candidates: the BEGIN/END markers are
+# distinctive enough that no separate prefilter is really needed, but for
+# consistency we still anchor `_scan_candidates` on a cheap match. The
+# grammar's full pattern is essentially the same; both use re.DOTALL so the
+# base64 body can span lines.
+_X509_CERTIFICATE_CANDIDATE_RE = re.compile(
+    r"-----BEGIN CERTIFICATE-----.+?-----END CERTIFICATE-----",
+    re.DOTALL,
+)
+
+# Generic PEM block candidates (artifact). The candidate regex doesn't enforce
+# label symmetry — the grammar's backreference does. Without a backref here,
+# adjacent mismatched blocks would still be candidates, but the grammar
+# rejects them.
+_ARTIFACT_CANDIDATE_RE = re.compile(
+    r"-----BEGIN (?!CERTIFICATE-----)[A-Z][A-Z0-9 ]*-----.+?-----END [A-Z][A-Z0-9 ]*-----",
+    re.DOTALL,
+)
+
 _FILE_PATH_CANDIDATE_RE = re.compile(
     r"(?<![A-Za-z0-9])"
     r"(?:"
@@ -250,6 +269,7 @@ IndicatorDict = dict[str, IndicatorList]
 IndicatorData = Mapping[str, IndicatorList | IndicatorDict]
 
 SUPPORTED_IOC_TYPES = [
+    "artifacts",
     "asns",
     "attack_mitigations",
     "attack_tactics",
@@ -279,6 +299,7 @@ SUPPORTED_IOC_TYPES = [
     "urls",
     "urls_complete",
     "user_agents",
+    "x509_certificates",
     "xmpp_addresses",
 ]
 
@@ -714,6 +735,16 @@ def parse_file_paths(text):
     return _scan_candidates(text, _FILE_PATH_CANDIDATE_RE, ioc_grammars.file_path)
 
 
+def parse_x509_certificates(text):
+    """."""
+    return _scan_candidates(text, _X509_CERTIFICATE_CANDIDATE_RE, ioc_grammars.x509_certificate)
+
+
+def parse_artifacts(text):
+    """."""
+    return _scan_candidates(text, _ARTIFACT_CANDIDATE_RE, ioc_grammars.artifact)
+
+
 def parse_pre_attack_tactics(text):
     """."""
     return _scan_candidates(text, _ATTACK_TACTIC_CANDIDATE_RE, ioc_grammars.pre_attack_tactics_grammar)
@@ -888,6 +919,20 @@ def find_iocs(
     text = prepare_text(text)
     # keep a copy of the original text - some items should be parsed from the original text
     original_text = text
+
+    # PEM blocks (x509 certificates and other artifacts). Extract first and
+    # strip from `text` so that hex runs inside the base64 body don't surface
+    # as md5/sha1/sha256, etc. We always strip regardless of whether the
+    # caller asked for these IOC types — leaving them in would corrupt other
+    # parsers' output.
+    x509_certificates = parse_x509_certificates(text)
+    artifacts = parse_artifacts(text)
+    if "x509_certificates" in included_ioc_types:
+        iocs["x509_certificates"] = x509_certificates
+    if "artifacts" in included_ioc_types:
+        iocs["artifacts"] = artifacts
+    text = _remove_items(x509_certificates, text)
+    text = _remove_items(artifacts, text)
 
     # urls
     if "urls" in included_ioc_types:

--- a/ioc_finder/ioc_grammars.py
+++ b/ioc_finder/ioc_grammars.py
@@ -469,3 +469,26 @@ tlp_label = Combine(
     + Or([Literal(":"), Literal("-"), Literal(" "), Empty()]).set_parse_action(lambda x: ":")
     + tlp_colors
 ).set_parse_action(pyparsing_common.upcase_tokens)
+
+# PEM-encoded X.509 certificate (RFC 7468). The STIX 2.1 X509Certificate SCO is
+# a richer object (issuer, subject, validity, hashes, ...), but raw certificates
+# in threat reports virtually always appear as a `-----BEGIN CERTIFICATE-----`
+# PEM block, so that's what we extract. Lazy `.+?` with DOTALL keeps the match
+# bounded to the first matching END marker.
+x509_certificate = Regex(
+    r"-----BEGIN CERTIFICATE-----.+?-----END CERTIFICATE-----",
+    flags=re.DOTALL,
+)
+
+# Generic PEM block — STIX 2.1 Artifact SCO models opaque bytes (mime_type +
+# payload_bin). In threat reports these typically surface as PEM blocks for
+# private keys, PGP messages, public keys, CRLs, CSRs, etc. We exclude the
+# `CERTIFICATE` label (handled by `x509_certificate`) but accept everything
+# else, including `CERTIFICATE REQUEST` (a CSR is a request, not a cert).
+# The backreference \1 enforces label symmetry between BEGIN and END.
+artifact = Regex(
+    r"-----BEGIN (?!CERTIFICATE-----)([A-Z][A-Z0-9]*(?: [A-Z][A-Z0-9]*)*)-----"
+    r".+?"
+    r"-----END \1-----",
+    flags=re.DOTALL,
+)

--- a/tests/find_iocs_cases/__init__.py
+++ b/tests/find_iocs_cases/__init__.py
@@ -10,6 +10,7 @@ from .hashes import HASH_DATA
 from .ids import ID_DATA
 from .ip_addr import IP_DATA
 from .mac_addr import MAC_DATA
+from .pem_blocks import PEM_DATA
 from .registry_keys import REGISTRY_DATA
 from .tlp_labels import TLP_DATA
 from .urls import URL_DATA
@@ -31,6 +32,7 @@ cases = [
     ID_DATA,
     COIN_DATA,
     MAC_DATA,
+    PEM_DATA,
     URL_DATA,
     UA_DATA,
 ]

--- a/tests/find_iocs_cases/feature__included_ioc_types.py
+++ b/tests/find_iocs_cases/feature__included_ioc_types.py
@@ -48,12 +48,8 @@ IOC_EXAMPLES = {
     "attack_mitigations": {"enterprise": ["M1036", "M1015"]},
     "attack_tactics": {"pre_attack": ["TA0012"]},
     "attack_techniques": {"pre_attack": ["T1329"]},
-    "x509_certificates": [
-        "-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiGCgKCAQEA\n-----END CERTIFICATE-----"
-    ],
-    "artifacts": [
-        "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiGAASCBKcwggSjAgEA\n-----END PRIVATE KEY-----"
-    ],
+    "x509_certificates": ["-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiGCgKCAQEA\n-----END CERTIFICATE-----"],
+    "artifacts": ["-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiGAASCBKcwggSjAgEA\n-----END PRIVATE KEY-----"],
 }
 all_ioc_text = " ".join([val for sublist in IOC_EXAMPLES.values() for val in sublist])
 

--- a/tests/find_iocs_cases/feature__included_ioc_types.py
+++ b/tests/find_iocs_cases/feature__included_ioc_types.py
@@ -48,6 +48,12 @@ IOC_EXAMPLES = {
     "attack_mitigations": {"enterprise": ["M1036", "M1015"]},
     "attack_tactics": {"pre_attack": ["TA0012"]},
     "attack_techniques": {"pre_attack": ["T1329"]},
+    "x509_certificates": [
+        "-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiGCgKCAQEA\n-----END CERTIFICATE-----"
+    ],
+    "artifacts": [
+        "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiGAASCBKcwggSjAgEA\n-----END PRIVATE KEY-----"
+    ],
 }
 all_ioc_text = " ".join([val for sublist in IOC_EXAMPLES.values() for val in sublist])
 

--- a/tests/find_iocs_cases/pem_blocks.py
+++ b/tests/find_iocs_cases/pem_blocks.py
@@ -14,11 +14,7 @@ _PRIVATE_KEY_BLOCK = (
     "-----END PRIVATE KEY-----"
 )
 
-_PGP_BLOCK = (
-    "-----BEGIN PGP MESSAGE-----\n"
-    "hQEMA1234567890ABCDEFG/HiJklMnOpQrStUv/Wxyz0\n"
-    "-----END PGP MESSAGE-----"
-)
+_PGP_BLOCK = "-----BEGIN PGP MESSAGE-----\nhQEMA1234567890ABCDEFG/HiJklMnOpQrStUv/Wxyz0\n-----END PGP MESSAGE-----"
 
 _CSR_BLOCK = (
     "-----BEGIN CERTIFICATE REQUEST-----\n"
@@ -77,9 +73,7 @@ PEM_DATA = [
     param(
         # PEM body contains a 32-char hex-only run that would otherwise
         # match as an md5. Stripping must prevent that.
-        "-----BEGIN CERTIFICATE-----\n"
-        "abcdef0123456789abcdef0123456789\n"
-        "-----END CERTIFICATE-----",
+        "-----BEGIN CERTIFICATE-----\nabcdef0123456789abcdef0123456789\n-----END CERTIFICATE-----",
         {
             "x509_certificates": [
                 "-----BEGIN CERTIFICATE-----\nabcdef0123456789abcdef0123456789\n-----END CERTIFICATE-----"

--- a/tests/find_iocs_cases/pem_blocks.py
+++ b/tests/find_iocs_cases/pem_blocks.py
@@ -1,0 +1,92 @@
+from pytest import param
+
+_X509_BLOCK = (
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\n"
+    "vQIBADANBgkqhkiGCgKCAQEAvQIBADANBgkqhkiGCgKC\n"
+    "-----END CERTIFICATE-----"
+)
+
+_PRIVATE_KEY_BLOCK = (
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEA\n"
+    "AoIBAQCqGKukO1De7zhZj6CKwG28ZMUFQAEMLJVOmZTI\n"
+    "-----END PRIVATE KEY-----"
+)
+
+_PGP_BLOCK = (
+    "-----BEGIN PGP MESSAGE-----\n"
+    "hQEMA1234567890ABCDEFG/HiJklMnOpQrStUv/Wxyz0\n"
+    "-----END PGP MESSAGE-----"
+)
+
+_CSR_BLOCK = (
+    "-----BEGIN CERTIFICATE REQUEST-----\n"
+    "MIICijCCAXICAQAwRTELMAkGA1UEBhMCQVUxEzARBgNV\n"
+    "-----END CERTIFICATE REQUEST-----"
+)
+
+PEM_DATA = [
+    param(
+        f"Pinned cert in malware sample:\n{_X509_BLOCK}\nend of report",
+        {"x509_certificates": [_X509_BLOCK]},
+        {},
+        id="x509_pem_certificate",
+    ),
+    param(
+        f"Embedded private key:\n{_PRIVATE_KEY_BLOCK}",
+        {"artifacts": [_PRIVATE_KEY_BLOCK]},
+        {},
+        id="artifact_pem_private_key",
+    ),
+    param(
+        f"Operator's PGP message: {_PGP_BLOCK}",
+        {"artifacts": [_PGP_BLOCK]},
+        {},
+        id="artifact_pem_pgp_message",
+    ),
+    param(
+        f"CSR is not a cert: {_CSR_BLOCK}",
+        {"artifacts": [_CSR_BLOCK], "x509_certificates": []},
+        {},
+        id="artifact_pem_csr_not_certificate",
+    ),
+    param(
+        f"Two together:\n{_X509_BLOCK}\n{_PRIVATE_KEY_BLOCK}",
+        {
+            "x509_certificates": [_X509_BLOCK],
+            "artifacts": [_PRIVATE_KEY_BLOCK],
+        },
+        {},
+        id="x509_and_artifact_together",
+    ),
+    param(
+        # Mismatched BEGIN/END labels — must NOT match.
+        "-----BEGIN CERTIFICATE-----\nAAA\n-----END PRIVATE KEY-----",
+        {"x509_certificates": [], "artifacts": []},
+        {},
+        id="pem_mismatched_labels_rejected",
+    ),
+    param(
+        # Unterminated BEGIN — must NOT match.
+        "-----BEGIN CERTIFICATE-----\nMIIBIjANBgkqhkiG9w0BAQEFAA",
+        {"x509_certificates": [], "artifacts": []},
+        {},
+        id="pem_unterminated_rejected",
+    ),
+    param(
+        # PEM body contains a 32-char hex-only run that would otherwise
+        # match as an md5. Stripping must prevent that.
+        "-----BEGIN CERTIFICATE-----\n"
+        "abcdef0123456789abcdef0123456789\n"
+        "-----END CERTIFICATE-----",
+        {
+            "x509_certificates": [
+                "-----BEGIN CERTIFICATE-----\nabcdef0123456789abcdef0123456789\n-----END CERTIFICATE-----"
+            ],
+            "md5s": [],
+        },
+        {},
+        id="pem_body_hex_not_parsed_as_md5",
+    ),
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,7 @@ def test_cli_without_domain_from_url_parsing():
     assert (
         result.output.strip()
         == """{
+    "artifacts": [],
     "asns": [],
     "attack_mitigations": {
         "enterprise": [],
@@ -84,6 +85,7 @@ def test_cli_without_domain_from_url_parsing():
         "https://example.org/test/bingo.php"
     ],
     "user_agents": [],
+    "x509_certificates": [],
     "xmpp_addresses": []
 }"""
     )


### PR DESCRIPTION
## Changes

- Add `x509_certificates` IOC type — matches PEM-encoded `-----BEGIN CERTIFICATE-----` blocks (RFC 7468)
- Add `artifacts` IOC type — matches any other PEM block (private keys, PGP messages, CSRs, public keys, CRLs, etc.) with a backreference enforcing BEGIN/END label symmetry
- Both are extracted at the top of `find_iocs` and stripped from the working text so base64 bodies don't pollute hash/domain/etc. parsers
- Add candidate prefilter regexes (`_X509_CERTIFICATE_CANDIDATE_RE`, `_ARTIFACT_CANDIDATE_RE`) following the existing grammar + prefilter pattern
- Export `parse_x509_certificates` and `parse_artifacts` from `ioc_finder`
- Register both in `SUPPORTED_IOC_TYPES`
- Add `tests/find_iocs_cases/pem_blocks.py` with 8 cases: x509 cert, private key, PGP message, CSR (artifact, not cert), x509+artifact together, mismatched-label rejection, unterminated rejection, hex-body-not-md5 isolation
- Update `feature__included_ioc_types.py` and `test_cli.py` for the new types

Network traffic, File, and Directory types from #299 are not included in this PR.