### PR TITLE
Add Snort and Yara rule parsers (#163)

### DIFF
--- a/ioc_finder/__init__.py
+++ b/ioc_finder/__init__.py
@@ -32,11 +32,13 @@ from .ioc_finder import (
     parse_sha1s,
     parse_sha256s,
     parse_sha512s,
+    parse_snort_rules,
     parse_ssdeeps,
     parse_tlp_labels,
     parse_urls,
     parse_user_agents,
     parse_xmpp_addresses,
+    parse_yara_rules,
     prepare_text,
 )
 
@@ -76,10 +78,12 @@ __all__ = [
     "parse_sha1s",
     "parse_sha256s",
     "parse_sha512s",
+    "parse_snort_rules",
     "parse_ssdeeps",
     "parse_tlp_labels",
     "parse_urls",
     "parse_user_agents",
     "parse_xmpp_addresses",
+    "parse_yara_rules",
     "prepare_text",
 ]

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -225,6 +225,50 @@ _SSDEEP_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9])\d+:[A-Za-z0-9/+]{3,}:[A-Za-
 # alphabet excludes '0', 'I', 'O', 'l' (Base58).
 _MONERO_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9])4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}(?![A-Za-z0-9])")
 
+# Snort/Suricata-rule candidate header: the rule's leading "<action> <proto>
+# <src> <sport> <dir> <dst> <dport> (" up to the opening paren of the body.
+# The body is then walked in Python by `_extract_snort_rule_body` so we can
+# count parens while skipping over double-quoted content (where unbalanced
+# parens inside `content:"…"` / `pcre:"…"` strings would otherwise throw the
+# count off). Action and protocol lists mirror Snort 3 / Suricata 7 docs;
+# this is intentionally a superset — the `sid:<digits>` post-condition is
+# what discriminates real rules from prose like "drop udp connections".
+_SNORT_HEADER_RE = re.compile(
+    r"(?<![A-Za-z0-9])"
+    r"(?:alert|log|pass|activate|dynamic|drop|reject|sdrop|rejectsrc|rejectdst|rejectboth)"
+    r"[ \t]+"
+    r"[a-z][a-z0-9-]{1,30}"
+    r"[ \t]+"
+    r"\S+[ \t]+\S+[ \t]+"
+    r"(?:->|<>|<-)"
+    r"[ \t]+\S+[ \t]+\S+[ \t]*"
+    r"\("
+)
+
+# `sid:<digits>` is a required option in any complete Snort rule
+# (https://docs.snort.org/rules/options/general/sid). Used as the post-
+# condition that promotes a candidate header into a real rule.
+_SNORT_SID_RE = re.compile(r"\bsid\s*:\s*\d+")
+
+# Yara-rule candidate header: optional `private`/`global` modifiers + `rule`
+# + identifier + optional `: tag tag…` + opening `{`. Body brace-walking
+# happens in `_extract_yara_rule_body`. Identifier rules from the Yara
+# language spec: starts with `[A-Za-z_]`, body `[A-Za-z0-9_]`, max 128 chars.
+_YARA_HEADER_RE = re.compile(
+    r"(?<![A-Za-z0-9_])"
+    r"(?:(?:private|global)\s+){0,2}"
+    r"rule\s+"
+    r"[A-Za-z_][A-Za-z0-9_]{0,127}"
+    r"(?:\s*:\s*[A-Za-z_][A-Za-z0-9_]*(?:\s+[A-Za-z_][A-Za-z0-9_]*)*)?"
+    r"\s*\{"
+)
+
+# `condition:` is the only mandatory section of a Yara rule
+# (https://yara.readthedocs.io/en/stable/writingrules.html). Used as the
+# post-condition to filter out incomplete or coincidental `rule X { … }`
+# constructs.
+_YARA_CONDITION_RE = re.compile(r"\bcondition\s*:")
+
 # File-path candidates: the file_path grammar accepts either a Windows path
 # (drive letter + ':' + dotless body + '.' + 1–5 letter extension) or a Unix
 # path (starting '~' or '/', same body+extension shape, with a "//" not in
@@ -274,12 +318,14 @@ SUPPORTED_IOC_TYPES = [
     "sha1s",
     "sha256s",
     "sha512s",
+    "snort_rules",
     "ssdeeps",
     "tlp_labels",
     "urls",
     "urls_complete",
     "user_agents",
     "xmpp_addresses",
+    "yara_rules",
 ]
 
 DEFAULT_IOC_TYPES = [
@@ -714,6 +760,155 @@ def parse_file_paths(text):
     return _scan_candidates(text, _FILE_PATH_CANDIDATE_RE, ioc_grammars.file_path)
 
 
+def _extract_snort_rule_body(text: str, body_start: int) -> int | None:
+    """Return the index just past the matching `)` for a Snort rule whose
+    `(` sits at `body_start - 1`. Walks paren depth while skipping over
+    double-quoted content; returns None if the parens never balance (e.g.
+    truncated rule at end of buffer)."""
+    depth = 1
+    i = body_start
+    n = len(text)
+    while i < n and depth > 0:
+        c = text[i]
+        if c == '"':
+            i += 1
+            while i < n and text[i] != '"':
+                # Snort options use `\;` and `\"` escapes inside quoted values;
+                # an escape consumes the next char rather than terminating the
+                # string, otherwise a `\"` would close the string prematurely.
+                if text[i] == "\\" and i + 1 < n:
+                    i += 2
+                else:
+                    i += 1
+            i += 1
+            continue
+        if c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+        i += 1
+    return i if depth == 0 else None
+
+
+def parse_snort_rules(text: str) -> list:
+    """Find Snort/Suricata rules in `text`.
+
+    Each match is the full rule text, from the action keyword through the
+    closing `)` of the option body. Rules must contain a `sid:<digits>`
+    option to be returned, which filters out prose containing action/proto
+    keywords (e.g. "drop udp connections")."""
+    seen: set[str] = set()
+    out: list[str] = []
+    pos = 0
+    n = len(text)
+    while pos < n:
+        m = _SNORT_HEADER_RE.search(text, pos)
+        if not m:
+            break
+        end = _extract_snort_rule_body(text, m.end())
+        if end is None:
+            # Unbalanced — give up on this anchor but allow searches inside
+            # the would-be body so a real rule nested after broken text is
+            # still found.
+            pos = m.end()
+            continue
+        rule = text[m.start() : end]
+        if _SNORT_SID_RE.search(rule) and rule not in seen:
+            seen.add(rule)
+            out.append(rule)
+        pos = end
+    return out
+
+
+def _extract_yara_rule_body(text: str, body_start: int) -> int | None:
+    """Return the index just past the matching `}` for a Yara rule whose
+    `{` sits at `body_start - 1`. Yara's hex strings, regex literals,
+    quoted strings, and both line/block comment styles can each contain
+    characters that look like braces; this walker skips over them so the
+    outer brace count reflects only the rule body's own structure."""
+    depth = 1
+    i = body_start
+    n = len(text)
+    while i < n and depth > 0:
+        c = text[i]
+        # /* block comment */
+        if c == "/" and i + 1 < n and text[i + 1] == "*":
+            close = text.find("*/", i + 2)
+            i = (close + 2) if close != -1 else n
+            continue
+        # // line comment
+        if c == "/" and i + 1 < n and text[i + 1] == "/":
+            nl = text.find("\n", i + 2)
+            i = (nl + 1) if nl != -1 else n
+            continue
+        # double-quoted string literal
+        if c == '"':
+            i += 1
+            while i < n and text[i] != '"':
+                if text[i] == "\\" and i + 1 < n:
+                    i += 2
+                else:
+                    i += 1
+            i += 1
+            continue
+        # /regex/ literal — only treat `/` as a regex opener if a closing `/`
+        # appears on the same line (the Yara grammar's regex literals don't
+        # span newlines). This avoids mis-classifying division-like usage in
+        # `condition:` expressions, though Yara has no `/` operator anyway.
+        if c == "/":
+            j = i + 1
+            while j < n and text[j] != "/" and text[j] != "\n":
+                if text[j] == "\\" and j + 1 < n:
+                    j += 2
+                else:
+                    j += 1
+            if j < n and text[j] == "/":
+                i = j + 1
+                # consume regex flags (i, s, g — the Yara-supported subset)
+                while i < n and text[i] in "isg":
+                    i += 1
+                continue
+            # No closing `/`; treat as a literal slash.
+            i += 1
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+        i += 1
+    return i if depth == 0 else None
+
+
+def parse_yara_rules(text: str) -> list:
+    """Find Yara rules in `text`.
+
+    Each match is the full rule text, from the (optional) `private`/`global`
+    modifiers through the closing `}`. Rules must contain a `condition:`
+    keyword to be returned — that's the one mandatory Yara section, and
+    it filters out empty stubs and the bare phrase "rule X { … }" used in
+    natural-language prose."""
+    seen: set[str] = set()
+    out: list[str] = []
+    pos = 0
+    n = len(text)
+    while pos < n:
+        m = _YARA_HEADER_RE.search(text, pos)
+        if not m:
+            break
+        end = _extract_yara_rule_body(text, m.end())
+        if end is None:
+            # Body never balances — advance past the header so a real rule
+            # later in the buffer is still found, but skip this anchor.
+            pos = m.end()
+            continue
+        rule = text[m.start() : end]
+        if _YARA_CONDITION_RE.search(rule) and rule not in seen:
+            seen.add(rule)
+            out.append(rule)
+        pos = end
+    return out
+
+
 def parse_pre_attack_tactics(text):
     """."""
     return _scan_candidates(text, _ATTACK_TACTIC_CANDIDATE_RE, ioc_grammars.pre_attack_tactics_grammar)
@@ -1054,6 +1249,18 @@ def find_iocs(
             "enterprise": parse_enterprise_attack_techniques(original_text),
             "mobile": parse_mobile_attack_techniques(original_text),
         }
+
+    # snort/yara rules — extracted from `original_text` so rule contents
+    # aren't disturbed by `prepare_text` fanging or by upstream IOC removals
+    # (e.g. URL stripping). We don't strip the rule bodies from `text`
+    # afterwards: a rule containing IOCs (hashes in `meta:`, IPs in a Snort
+    # header) is itself an indicator, but downstream callers may also want
+    # those embedded IOCs surfaced individually — same pragmatism as how
+    # registry_key_paths and file_paths don't strip themselves either.
+    if "snort_rules" in included_ioc_types:
+        iocs["snort_rules"] = parse_snort_rules(original_text)
+    if "yara_rules" in included_ioc_types:
+        iocs["yara_rules"] = parse_yara_rules(original_text)
 
     if "file_paths" in included_ioc_types:
         # if there are still url paths in the text, remove them so they don't get parsed as file names

--- a/tests/find_iocs_cases/__init__.py
+++ b/tests/find_iocs_cases/__init__.py
@@ -11,9 +11,11 @@ from .ids import ID_DATA
 from .ip_addr import IP_DATA
 from .mac_addr import MAC_DATA
 from .registry_keys import REGISTRY_DATA
+from .snort_rules import SNORT_DATA
 from .tlp_labels import TLP_DATA
 from .urls import URL_DATA
 from .user_agents import UA_DATA
+from .yara_rules import YARA_DATA
 
 cases = [
     TLP_DATA,
@@ -33,6 +35,8 @@ cases = [
     MAC_DATA,
     URL_DATA,
     UA_DATA,
+    SNORT_DATA,
+    YARA_DATA,
 ]
 
 ALL_TESTS = [val for sublist in cases for val in sublist]

--- a/tests/find_iocs_cases/feature__included_ioc_types.py
+++ b/tests/find_iocs_cases/feature__included_ioc_types.py
@@ -45,6 +45,8 @@ IOC_EXAMPLES = {
     ],  # I don't like this parsing... I've ticketed this for improvement here: https://github.com/fhightower/ioc-finder/issues/227
     "tlp_labels": ["TLP:RED"],
     "file_paths": ["~/foo/bar/abc.py"],
+    "snort_rules": ['alert tcp any any -> any 80 (msg:"WEB-MISC test"; sid:1000001; rev:1;)'],
+    "yara_rules": ['rule TestRule { strings: $a = "evil" condition: $a }'],
     "attack_mitigations": {"enterprise": ["M1036", "M1015"]},
     "attack_tactics": {"pre_attack": ["TA0012"]},
     "attack_techniques": {"pre_attack": ["T1329"]},

--- a/tests/find_iocs_cases/snort_rules.py
+++ b/tests/find_iocs_cases/snort_rules.py
@@ -1,0 +1,65 @@
+from pytest import param
+
+SIMPLE_SNORT_RULE = 'alert tcp any any -> any 80 (msg:"WEB-MISC test"; sid:1000001; rev:1;)'
+
+SNORT_DATA = [
+    param(
+        SIMPLE_SNORT_RULE,
+        {"snort_rules": [SIMPLE_SNORT_RULE]},
+        {"included_ioc_types": ["snort_rules"]},
+        id="snort_simple",
+    ),
+    param(
+        # Two rules on consecutive lines should both be returned, in order.
+        'alert tcp any any -> any 80 (msg:"first"; sid:1;)\ndrop udp $HOME_NET any -> any 53 (msg:"second"; sid:2;)',
+        {
+            "snort_rules": [
+                'alert tcp any any -> any 80 (msg:"first"; sid:1;)',
+                'drop udp $HOME_NET any -> any 53 (msg:"second"; sid:2;)',
+            ]
+        },
+        {"included_ioc_types": ["snort_rules"]},
+        id="snort_multiple",
+    ),
+    param(
+        # Inline pcre with a parenthesised group must not throw off the
+        # paren counter; the body has nested () and an embedded ;.
+        'alert http any any -> any any (msg:"PCRE test"; pcre:"/foo(?:bar|baz)quux/i"; sid:42;)',
+        {"snort_rules": ['alert http any any -> any any (msg:"PCRE test"; pcre:"/foo(?:bar|baz)quux/i"; sid:42;)']},
+        {"included_ioc_types": ["snort_rules"]},
+        id="snort_pcre_with_nested_parens",
+    ),
+    param(
+        # Quoted strings inside the body may contain `)` — the extractor
+        # must skip parens inside double-quoted runs.
+        'alert tcp any any -> any any (msg:"smiley :)"; sid:7;)',
+        {"snort_rules": ['alert tcp any any -> any any (msg:"smiley :)"; sid:7;)']},
+        {"included_ioc_types": ["snort_rules"]},
+        id="snort_paren_in_quoted_msg",
+    ),
+    param(
+        # Rule embedded between paragraphs of prose.
+        "Here is the rule the team wrote:\n"
+        '   alert tcp any any -> 10.0.0.0/8 22 (msg:"SSH attempt"; sid:9001;)\n'
+        "and that's what we deployed.",
+        {"snort_rules": ['alert tcp any any -> 10.0.0.0/8 22 (msg:"SSH attempt"; sid:9001;)']},
+        {"included_ioc_types": ["snort_rules"]},
+        id="snort_embedded_in_prose",
+    ),
+    param(
+        # Action+proto words in plain English must NOT match — the lack of
+        # a `sid:` discriminator filters them out.
+        "We had to drop udp traffic at any port.",
+        {"snort_rules": []},
+        {"included_ioc_types": ["snort_rules"]},
+        id="snort_prose_no_sid",
+    ),
+    param(
+        # An unbalanced rule (truncated, missing close paren) must be
+        # rejected rather than swallowing the rest of the document.
+        'alert tcp any any -> any 80 (msg:"truncated"; sid:1;\nAnd here is the next paragraph.',
+        {"snort_rules": []},
+        {"included_ioc_types": ["snort_rules"]},
+        id="snort_unbalanced_rejected",
+    ),
+]

--- a/tests/find_iocs_cases/yara_rules.py
+++ b/tests/find_iocs_cases/yara_rules.py
@@ -1,0 +1,114 @@
+from pytest import param
+
+SIMPLE_YARA_RULE = 'rule TestRule { strings: $a = "evil" condition: $a }'
+
+YARA_DATA = [
+    param(
+        SIMPLE_YARA_RULE,
+        {"yara_rules": [SIMPLE_YARA_RULE]},
+        {"included_ioc_types": ["yara_rules"]},
+        id="yara_simple",
+    ),
+    param(
+        # private/global modifiers + tags + meta + strings + condition
+        "private global rule FullExample : malware trojan {\n"
+        "    meta:\n"
+        '        author = "ioc-finder"\n'
+        '        description = "exercise every section"\n'
+        "    strings:\n"
+        '        $a = "evil"\n'
+        "        $b = { 4D 5A 90 ?? [4-6] (62 | 63) }\n"
+        "        $c = /md5: [0-9a-f]{32}/i\n"
+        "    condition:\n"
+        "        any of them\n"
+        "}",
+        {
+            "yara_rules": [
+                "private global rule FullExample : malware trojan {\n"
+                "    meta:\n"
+                '        author = "ioc-finder"\n'
+                '        description = "exercise every section"\n'
+                "    strings:\n"
+                '        $a = "evil"\n'
+                "        $b = { 4D 5A 90 ?? [4-6] (62 | 63) }\n"
+                "        $c = /md5: [0-9a-f]{32}/i\n"
+                "    condition:\n"
+                "        any of them\n"
+                "}"
+            ]
+        },
+        {"included_ioc_types": ["yara_rules"]},
+        id="yara_full_with_modifiers_tags_hex_regex",
+    ),
+    param(
+        # Two rules back-to-back must both be returned, with `import` lines
+        # in between left out of the matches.
+        'rule One { condition: true }\n\nimport "pe"\n\nrule Two { strings: $s = "x" condition: $s }',
+        {
+            "yara_rules": [
+                "rule One { condition: true }",
+                'rule Two { strings: $s = "x" condition: $s }',
+            ]
+        },
+        {"included_ioc_types": ["yara_rules"]},
+        id="yara_multiple_rules_with_import_between",
+    ),
+    param(
+        # A `}` inside a quoted string must not close the rule body.
+        'rule QuoteEscape { strings: $a = "close }" condition: $a }',
+        {"yara_rules": ['rule QuoteEscape { strings: $a = "close }" condition: $a }']},
+        {"included_ioc_types": ["yara_rules"]},
+        id="yara_brace_in_quoted_string",
+    ),
+    param(
+        # `}` inside a /regex/ literal must not close the rule body either.
+        "rule RegexEscape { strings: $a = /a}b/ condition: $a }",
+        {"yara_rules": ["rule RegexEscape { strings: $a = /a}b/ condition: $a }"]},
+        {"included_ioc_types": ["yara_rules"]},
+        id="yara_brace_in_regex",
+    ),
+    param(
+        # Block and line comments may contain stray braces — both must be
+        # stepped over by the body walker.
+        "rule Commented {\n"
+        "    /* a } stray brace in a block comment */\n"
+        "    // and a } in a line comment\n"
+        "    condition: true\n"
+        "}",
+        {
+            "yara_rules": [
+                "rule Commented {\n"
+                "    /* a } stray brace in a block comment */\n"
+                "    // and a } in a line comment\n"
+                "    condition: true\n"
+                "}"
+            ]
+        },
+        {"included_ioc_types": ["yara_rules"]},
+        id="yara_brace_in_comments",
+    ),
+    param(
+        # No `condition:` keyword: not a real rule, must be rejected.
+        'rule Stub { strings: $a = "x" }',
+        {"yara_rules": []},
+        {"included_ioc_types": ["yara_rules"]},
+        id="yara_no_condition_rejected",
+    ),
+    param(
+        # Word "rule" in prose followed by a code-fence-shaped block must
+        # not match because the block has no `condition:`.
+        "Each rule X { does what you would expect } in this DSL.",
+        {"yara_rules": []},
+        {"included_ioc_types": ["yara_rules"]},
+        id="yara_prose_rejected",
+    ),
+    param(
+        # Embedded inside a paragraph of report text.
+        "We deployed the following rule to all sensors:\n\n"
+        "rule Deployed { condition: true }\n\n"
+        "and observed three hits in the first hour.",
+        {"yara_rules": ["rule Deployed { condition: true }"]},
+        {"included_ioc_types": ["yara_rules"]},
+        id="yara_embedded_in_prose",
+    ),
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,6 +75,7 @@ def test_cli_without_domain_from_url_parsing():
     "sha1s": [],
     "sha256s": [],
     "sha512s": [],
+    "snort_rules": [],
     "ssdeeps": [],
     "tlp_labels": [],
     "urls": [
@@ -84,7 +85,8 @@ def test_cli_without_domain_from_url_parsing():
         "https://example.org/test/bingo.php"
     ],
     "user_agents": [],
-    "xmpp_addresses": []
+    "xmpp_addresses": [],
+    "yara_rules": []
 }"""
     )
 

--- a/tests/test_parsing_functions.py
+++ b/tests/test_parsing_functions.py
@@ -1,6 +1,6 @@
 """Make sure that the parsing functions for specific functions are imported properly."""
 
-from ioc_finder import parse_urls
+from ioc_finder import parse_snort_rules, parse_urls, parse_yara_rules
 from ioc_finder.ioc_finder import _url_candidate_spans
 
 
@@ -13,3 +13,96 @@ def test_url_candidate_spans_skip_markers_inside_expanded_span():
     text = ("a.a/" * 5000) + " https://example.com/path"
 
     assert list(_url_candidate_spans(text)) == [text.split()[0], "https://example.com/path"]
+
+
+def test_snort_rule_parsing_func():
+    rule = 'alert tcp any any -> any 80 (msg:"x"; sid:1;)'
+    assert parse_snort_rules(rule) == [rule]
+
+
+def test_snort_rule_dedup():
+    """Identical rules pasted twice in a document collapse to one match."""
+    rule = 'alert tcp any any -> any 80 (msg:"x"; sid:1;)'
+    assert parse_snort_rules(rule + "\n" + rule) == [rule]
+
+
+def test_snort_rule_after_unbalanced_anchor_still_found():
+    """An unbalanced/truncated rule must not prevent a real rule that comes
+    after it from being detected. The truncated anchor is skipped and the
+    search continues from just past its header."""
+    text = (
+        # Truncated rule — opens a paren but never closes it.
+        'alert tcp any any -> any 1 (msg:"truncated"; sid:1;\n'
+        # Real rule on the next line.
+        'alert tcp any any -> any 2 (msg:"ok"; sid:2;)'
+    )
+    rules = parse_snort_rules(text)
+    assert rules == ['alert tcp any any -> any 2 (msg:"ok"; sid:2;)']
+
+
+def test_yara_rule_parsing_func():
+    rule = "rule TestRule { condition: true }"
+    assert parse_yara_rules(rule) == [rule]
+
+
+def test_yara_rule_with_hex_string_braces():
+    """The outer rule's brace counter must include — and then balance —
+    the braces that wrap a Yara hex string."""
+    rule = "rule HexCheck { strings: $a = { 4D 5A } condition: $a }"
+    assert parse_yara_rules(rule) == [rule]
+
+
+def test_yara_rule_dedup():
+    rule = "rule TestRule { condition: true }"
+    assert parse_yara_rules(rule + "\n\n" + rule) == [rule]
+
+
+def test_yara_and_snort_no_match_on_empty_input():
+    assert parse_yara_rules("") == []
+    assert parse_snort_rules("") == []
+
+
+def test_snort_rule_with_escaped_quote_in_msg():
+    """`\\"` inside a Snort msg must not terminate the quoted span; the
+    backslash escape consumes the next char and the parser keeps going to
+    the real closing quote."""
+    rule = 'alert tcp any any -> any 80 (msg:"a\\"b"; sid:1;)'
+    assert parse_snort_rules(rule) == [rule]
+
+
+def test_yara_rule_escaped_quote_in_string():
+    """`\\"` inside a Yara string literal must not terminate the string
+    span; the brace counter must reach the real closing `"` before
+    treating any subsequent `}` as the rule close."""
+    rule = 'rule EscQuote { strings: $a = "a\\"}b" condition: $a }'
+    assert parse_yara_rules(rule) == [rule]
+
+
+def test_yara_rule_escape_in_regex():
+    """A `\\/` inside `/regex/` must not be treated as the regex's closing
+    delimiter — same escape rule as for double-quoted strings."""
+    rule = "rule EscRegex { strings: $a = /a\\/}b/ condition: $a }"
+    assert parse_yara_rules(rule) == [rule]
+
+
+def test_yara_rule_stray_slash_without_close():
+    """A `/` with no closing `/` on the same line must be treated as a
+    literal slash rather than starting an unterminated regex literal that
+    would swallow the rest of the buffer."""
+    # The `5/2` looks like a slash but there's no closing `/` on that line —
+    # the walker must fall back to literal-slash handling and keep going.
+    rule = "rule StraySlash { condition: 5/2 == 2 }"
+    assert parse_yara_rules(rule) == [rule]
+
+
+def test_yara_rule_unbalanced_anchor_skipped():
+    """An unclosed `rule X {` must not swallow downstream content; a real
+    rule that follows must still be returned."""
+    text = (
+        "rule Truncated {\n"
+        "    condition: true\n"
+        # Real rule afterwards.
+        "rule Good { condition: true }"
+    )
+    rules = parse_yara_rules(text)
+    assert rules == ["rule Good { condition: true }"]


### PR DESCRIPTION
## Changes

- Add `parse_snort_rules` — anchor regex for Snort/Suricata rule headers + paren-balanced body walker that skips over double-quoted strings; rules require `sid:<digits>` to be returned (filters action/proto keywords appearing in prose).
- Add `parse_yara_rules` — anchor regex for `[private|global] rule <Name> [: tags] {` + brace-balanced body walker that skips quoted strings, `/regex/` literals, and `//`/`/* */` comments; rules require `condition:` (the one mandatory Yara section).
- Both run against `original_text` so `prepare_text` fanging doesn't disturb rule contents.
- Add `snort_rules` and `yara_rules` to `SUPPORTED_IOC_TYPES` (opt-in, not in `DEFAULT_IOC_TYPES`, matching `file_paths`/`registry_key_paths`).
- Export `parse_snort_rules` / `parse_yara_rules` from the package.
- Tests: integration cases via the existing `find_iocs_cases` framework (simple, multi-rule, embedded-in-prose, nested parens, quoted-string and regex/comment escapes, hex-string braces, modifiers/tags, rejection of prose without `sid:`/`condition:`, unbalanced anchors); direct unit tests in `test_parsing_functions.py` for backslash-escape edge cases and unbalanced-anchor recovery.
- Update CLI `--all` snapshot test to include the two new keys.