### PR TITLE
Add parse_unicode_iocs option for Unicode domain labels (#298)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Added a `parse_unicode_iocs` option to `find_iocs` (and a `--parse_unicode_iocs` CLI flag), default `False` ([#298](https://github.com/fhightower/ioc-finder/issues/298)). When enabled, domain labels may contain non-ASCII (Unicode) characters — e.g. `warrıors.com` (note the dotless `ı`) is now parsed, as is the domain part of email, URL, and XMPP IOCs. The TLD itself stays ASCII (IANA stores internationalized TLDs in their `xn--` punycode form), as do email/URL/XMPP local parts and URL paths. The ASCII and Unicode grammar variants are generated from a single builder (`ioc_grammars._build_domain_layer`) so they can't drift.
+
 ## [9.3.0] - 2026.06.05
 
 ### Changed

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -35,7 +35,7 @@ You must pass some text into the `find_iocs()` function as string (the iocs will
 
 ##### Options
 
-The `find_iocs` takes the following keywords (all of them default to `True`):
+The `find_iocs` takes the following keywords (all of them default to `True`, except `parse_unicode_iocs` which defaults to `False`):
 
 - `parse_domain_from_url` (default=True): Whether or not to parse domain names from URLs (e.g. `example.com` from `https://example.com/test`). Only applicable when `"domains"` is in `included_ioc_types`.
 - `parse_from_url_path` (default=True): Whether or not to parse observables from URL paths (e.g. `2f3ec0e4998909bb0efab13c82d30708ca9f88679e42b75ef13ea0466951d862` from `https://www.virustotal.com/gui/file/2f3ec0e4998909bb0efab13c82d30708ca9f88679e42b75ef13ea0466951d862/detection`). Only applicable when IOC types that could appear in a URL path (e.g. `"domains"`, hash types) are in `included_ioc_types`.
@@ -43,6 +43,7 @@ The `find_iocs` takes the following keywords (all of them default to `True`):
 - `parse_address_from_cidr` (default=True): Whether or not to parse IP addresses from CIDR ranges (e.g. `0.0.0.1` from `0.0.0.1/24`). Only applicable when `"ipv4s"` or `"ipv6s"` are in `included_ioc_types`.
 - `parse_domain_name_from_xmpp_address` (default=True): Whether or not to parse domain names from XMPP addresses. Only applicable when `"domains"` is in `included_ioc_types`.
 - `parse_urls_without_scheme` (default=True): Whether or not to parse URLs without a scheme (see [https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Generic_syntax](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Generic_syntax)) (e.g. `hightower.space/projects`). Only applicable when `"urls"` or `"urls_complete"` is in `included_ioc_types`.
+- `parse_unicode_iocs` (default=False): Whether or not to allow non-ASCII (Unicode) characters in domain labels — e.g. `warrıors.com` (note the dotless `ı`), and the domain part of email, URL, and XMPP IOCs. The TLD itself is always ASCII (IANA stores internationalized TLDs in their `xn--` punycode form), as are email/URL/XMPP local parts and URL paths. Defaults to `False` so existing ASCII-only behavior is unchanged unless you opt in.
 - `included_ioc_types` (default=None): A collection of IOC type names to parse. When `None`, all default types are parsed. Valid values are: `"asns"`, `"attack_mitigations"`, `"attack_tactics"`, `"attack_techniques"`, `"authentihashes"`, `"bitcoin_addresses"`, `"cves"`, `"domains"`, `"email_addresses"`, `"email_addresses_complete"`, `"file_paths"`, `"google_adsense_publisher_ids"`, `"google_analytics_tracker_ids"`, `"imphashes"`, `"ipv4_cidrs"`, `"ipv4s"`, `"ipv6_cidrs"`, `"ipv6s"`, `"mac_addresses"`, `"md5s"`, `"monero_addresses"`, `"registry_key_paths"`, `"sha1s"`, `"sha256s"`, `"sha512s"`, `"socket_addresses"`, `"ssdeeps"`, `"tlp_labels"`, `"urls"`, `"urls_complete"`, `"user_agents"`, `"xmpp_addresses"`. Note that when using `included_ioc_types`, the boolean options above only take effect if their corresponding IOC type is included.
 
 See [test_ioc_finder.py](https://github.com/fhightower/ioc-finder/blob/master/tests/test_ioc_finder.py) for more examples.

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -200,9 +200,16 @@ _XMPP_CANDIDATE_RE = re.compile(
 # word and yields no domain (mirroring how `example.comX` yields none in ASCII
 # mode), whereas ASCII mode treats the `中` as a boundary and reports
 # `example.com`. This is a deliberate semantic difference, covered by
-# `test_unicode_boundary_semantics`. Local parts stay ASCII, matching the
-# email/XMPP local-part grammars (which parse_unicode_iocs leaves untouched).
-# See ioc_grammars._build_domain_layer for the corresponding grammar change.
+# `test_unicode_boundary_semantics`.
+#
+# Scope: the rule applies to *bare domains only*. The email/URL/XMPP grammars
+# keep the ASCII `alphanum_word_start`/`alphanum_word_end` boundaries even in
+# the Unicode layer, so `bob@example.com中` still yields `bob@example.com` in
+# both modes — Unicode mode never *removes* an email/URL/XMPP match that ASCII
+# mode finds. Also deliberate; pinned by the same test. Local parts stay
+# ASCII, matching the email/XMPP local-part grammars (which parse_unicode_iocs
+# leaves untouched). See ioc_grammars._build_domain_layer for the
+# corresponding grammar change.
 _DOMAIN_CANDIDATE_RE_UNICODE = re.compile(
     r"(?<![^\W_])"
     r"\w[\w-]{0,62}"

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -36,8 +36,9 @@ _ATTACK_TECHNIQUE_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9])T\d{4}[A-Za-z0-9.]
 # spans. Each label is capped at 63 chars to mirror ioc_grammars.label
 # (`Word(..., max=63)`); without the cap, a too-long-label run would over-capture
 # and hide an embedded valid domain (e.g. "<100 a's>.bar.com" → "bar.com" still
-# wants to surface). Char classes are otherwise ASCII-only — if IDN support is
-# ever added, both this regex and `ioc_grammars.label` need to change together.
+# wants to surface). Char classes are ASCII-only; the Unicode counterpart used
+# when find_iocs(..., parse_unicode_iocs=True) is `_DOMAIN_CANDIDATE_RE_UNICODE`
+# below (which tracks the Unicode `domain_labels` pattern in ioc_grammars).
 _DOMAIN_CANDIDATE_RE = re.compile(
     # Boundaries mirror ioc_grammars.alphanum_word_start / alphanum_word_end,
     # which only treat ASCII alphanumerics as word chars — so a domain may
@@ -188,6 +189,36 @@ _XMPP_CANDIDATE_RE = re.compile(
     r"[A-Za-z0-9][A-Za-z0-9+\-_.]*"
     r"@"
     r"[A-Za-z0-9._\-]*?(?i:jabber|xmpp)[A-Za-z0-9._\-]*"
+)
+
+# Unicode-aware variants of the domain / email / XMPP candidate regexes, used
+# when find_iocs(..., parse_unicode_iocs=True). They differ from their ASCII
+# counterparts above in the domain-label character class: `\w` (Unicode letters
+# of any script + digits + "_") in place of `[A-Za-z0-9_]`. The word-boundary
+# lookarounds use `[^\W_]` ("Unicode alphanumeric", no underscore) — in Unicode
+# mode a non-ASCII letter is a word character, so e.g. `example.com中` is one
+# word and yields no domain (mirroring how `example.comX` yields none in ASCII
+# mode), whereas ASCII mode treats the `中` as a boundary and reports
+# `example.com`. This is a deliberate semantic difference, covered by
+# `test_unicode_boundary_semantics`. Local parts stay ASCII, matching the
+# email/XMPP local-part grammars (which parse_unicode_iocs leaves untouched).
+# See ioc_grammars._build_domain_layer for the corresponding grammar change.
+_DOMAIN_CANDIDATE_RE_UNICODE = re.compile(
+    r"(?<![^\W_])"
+    r"\w[\w-]{0,62}"
+    r"(?:\.\w[\w-]{0,62})+"
+    r"(?![^\W_])"
+)
+_EMAIL_CANDIDATE_RE_UNICODE = re.compile(
+    r"(?:\\@|[A-Za-z0-9!#$%&'*+\-/=?^_`{|}~.\"()\\])+"
+    r"@"
+    r"(?:\[[^\]\s]{1,80}\]|[\w.\-]+)"
+)
+_XMPP_CANDIDATE_RE_UNICODE = re.compile(
+    r"(?<![A-Za-z0-9])"
+    r"[A-Za-z0-9][A-Za-z0-9+\-_.]*"
+    r"@"
+    r"[\w.\-]*?(?i:jabber|xmpp)[\w.\-]*"
 )
 
 # Bitcoin-address candidates: mirrors the three Regex() branches in the
@@ -380,37 +411,49 @@ def _clean_url(url: str) -> str:
     return url
 
 
-def parse_urls(text: str, *, parse_urls_without_scheme: bool = True) -> list:
+def _domain_grammars(parse_unicode_iocs: bool):
+    """Return the namespace of domain/email/URL/XMPP grammars to use: the
+    module-level ASCII grammars (``ioc_grammars``) or, when ``parse_unicode_iocs``
+    is set, the Unicode-aware layer from ``ioc_grammars.unicode_domain_layer()``.
+    Both expose the same attribute names (``domain_name``, ``email_address``,
+    ``scheme_less_url``, ...)."""
+    return ioc_grammars.unicode_domain_layer() if parse_unicode_iocs else ioc_grammars
+
+
+def parse_urls(text: str, *, parse_urls_without_scheme: bool = True, parse_unicode_iocs: bool = False) -> list:
     """."""
-    raw_urls, scheme_ful_spans = _scan_url_candidates_with_spans(text, ioc_grammars.url)
+    grammars = _domain_grammars(parse_unicode_iocs)
+    raw_urls, scheme_ful_spans = _scan_url_candidates_with_spans(text, grammars.url)
     raw_urls = list(raw_urls)
     if parse_urls_without_scheme:
         # Blank the exact spans the scheme-ful URLs occupy so the scheme-less
         # grammar can't re-discover their authority/path/query as a second URL.
         masked = _mask_spans(text, scheme_ful_spans)
-        raw_urls.extend(_scan_url_candidates(masked, ioc_grammars.scheme_less_url))
+        raw_urls.extend(_scan_url_candidates(masked, grammars.scheme_less_url))
     # Cleaning may collapse two raw matches to the same string, so dedupe again.
     return _deduplicate(map(_clean_url, raw_urls))
 
 
-def parse_urls_complete(text: str, *, parse_urls_without_scheme: bool = True) -> list:
+def parse_urls_complete(text: str, *, parse_urls_without_scheme: bool = True, parse_unicode_iocs: bool = False) -> list:
     """."""
-    raw_urls, scheme_ful_spans = _scan_url_candidates_with_spans(text, ioc_grammars.url_complete)
+    grammars = _domain_grammars(parse_unicode_iocs)
+    raw_urls, scheme_ful_spans = _scan_url_candidates_with_spans(text, grammars.url_complete)
     raw_urls = list(raw_urls)
     if parse_urls_without_scheme:
         masked = _mask_spans(text, scheme_ful_spans)
-        raw_urls.extend(_scan_url_candidates(masked, ioc_grammars.scheme_less_url_complete))
+        raw_urls.extend(_scan_url_candidates(masked, grammars.scheme_less_url_complete))
     return _deduplicate(map(_clean_url, raw_urls))
 
 
-def _parse_url(url: str) -> ParseResults:
+def _parse_url(url: str, *, parse_unicode_iocs: bool = False) -> ParseResults:
     """Parse a URL by trying the four URL grammars in order, since each may match
     a different shape of input (scheme-ful vs scheme-less, narrow vs complete)."""
+    grammars = _domain_grammars(parse_unicode_iocs)
     for grammar in (
-        ioc_grammars.url,
-        ioc_grammars.scheme_less_url,
-        ioc_grammars.url_complete,
-        ioc_grammars.scheme_less_url_complete,
+        grammars.url,
+        grammars.scheme_less_url,
+        grammars.url_complete,
+        grammars.scheme_less_url_complete,
     ):
         try:
             return grammar.parse_string(url)
@@ -419,10 +462,10 @@ def _parse_url(url: str) -> ParseResults:
     raise ParseException(url, msg=f"could not parse URL: {url!r}")
 
 
-def _remove_url_domain_name(urls: list, text: str) -> str:
+def _remove_url_domain_name(urls: list, text: str, *, parse_unicode_iocs: bool = False) -> str:
     """Remove the domain name of each url from the text."""
     for url in urls:
-        parsed_url = _parse_url(url)
+        parsed_url = _parse_url(url, parse_unicode_iocs=parse_unicode_iocs)
         url_authority = parsed_url.url_authority
         if isinstance(url_authority, ParseResults):
             url_authority = url_authority[0]
@@ -430,10 +473,10 @@ def _remove_url_domain_name(urls: list, text: str) -> str:
     return text
 
 
-def _remove_url_paths(urls: list, text: str) -> str:
+def _remove_url_paths(urls: list, text: str, *, parse_unicode_iocs: bool = False) -> str:
     """Remove the path of each url from the text."""
     for url in urls:
-        parsed_url = _parse_url(url)
+        parsed_url = _parse_url(url, parse_unicode_iocs=parse_unicode_iocs)
         url_path = urlparse.unquote_plus(parsed_url.url_path)
 
         is_cidr_range = parse_ipv4_cidrs(str(url))
@@ -443,12 +486,13 @@ def _remove_url_paths(urls: list, text: str) -> str:
     return text
 
 
-def _remove_url_userinfo(urls: list, text: str) -> str:
+def _remove_url_userinfo(urls: list, text: str, *, parse_unicode_iocs: bool = False) -> str:
     """Remove userinfo from each URL so it is not parsed as an email address."""
+    grammars = _domain_grammars(parse_unicode_iocs)
     for url in urls:
         # Only the "complete" grammars expose url_userinfo. Try both because
         # `scheme_less_url_complete` now rejects scheme-ful URLs.
-        for grammar in (ioc_grammars.url_complete, ioc_grammars.scheme_less_url_complete):
+        for grammar in (grammars.url_complete, grammars.scheme_less_url_complete):
             try:
                 parsed_url = grammar.parse_string(url)
                 break
@@ -468,11 +512,12 @@ def _percent_decode_url(urls: list, text: str) -> str:
     return text
 
 
-def parse_domain_names(text):
+def parse_domain_names(text, *, parse_unicode_iocs: bool = False):
     """."""
+    candidate_re = _DOMAIN_CANDIDATE_RE_UNICODE if parse_unicode_iocs else _DOMAIN_CANDIDATE_RE
     seen: set[str] = set()
     out: list[str] = []
-    for m in _DOMAIN_CANDIDATE_RE.finditer(text):
+    for m in candidate_re.finditer(text):
         candidate = m.group(0).lower()
         segments = candidate.split(".")
         # Walk segments right-to-left for the rightmost TLD that still
@@ -677,14 +722,16 @@ def _scan_validated(text, candidate_re, validator):
     return out
 
 
-def parse_complete_email_addresses(text: str) -> list:
+def parse_complete_email_addresses(text: str, *, parse_unicode_iocs: bool = False) -> list:
     """."""
-    return _scan_candidates(text, _EMAIL_CANDIDATE_RE, ioc_grammars.complete_email_address)
+    candidate_re = _EMAIL_CANDIDATE_RE_UNICODE if parse_unicode_iocs else _EMAIL_CANDIDATE_RE
+    return _scan_candidates(text, candidate_re, _domain_grammars(parse_unicode_iocs).complete_email_address)
 
 
-def parse_email_addresses(text: str) -> list:
+def parse_email_addresses(text: str, *, parse_unicode_iocs: bool = False) -> list:
     """."""
-    return _scan_candidates(text, _EMAIL_CANDIDATE_RE, ioc_grammars.email_address)
+    candidate_re = _EMAIL_CANDIDATE_RE_UNICODE if parse_unicode_iocs else _EMAIL_CANDIDATE_RE
+    return _scan_candidates(text, candidate_re, _domain_grammars(parse_unicode_iocs).email_address)
 
 
 # there is a trailing underscore on this function to differentiate it from the argument with the same name
@@ -801,9 +848,10 @@ def parse_monero_addresses(text):
     return _scan_candidates(text, _MONERO_CANDIDATE_RE, ioc_grammars.monero_address)
 
 
-def parse_xmpp_addresses(text: str) -> list:
+def parse_xmpp_addresses(text: str, *, parse_unicode_iocs: bool = False) -> list:
     """."""
-    return _scan_candidates(text, _XMPP_CANDIDATE_RE, ioc_grammars.xmpp_address)
+    candidate_re = _XMPP_CANDIDATE_RE_UNICODE if parse_unicode_iocs else _XMPP_CANDIDATE_RE
+    return _scan_candidates(text, candidate_re, _domain_grammars(parse_unicode_iocs).xmpp_address)
 
 
 def _remove_xmpp_local_part(xmpp_addresses: list, text: str) -> str:
@@ -927,6 +975,11 @@ def parse_tlp_labels(text):
     default=True,
 )
 @click.option(
+    "--parse_unicode_iocs",
+    is_flag=True,
+    help="Allow non-ASCII (Unicode) characters in domain labels (and the domain part of email/URL/XMPP IOCs)",
+)
+@click.option(
     "--all",
     "parse_all",
     is_flag=True,
@@ -940,6 +993,7 @@ def cli_find_iocs(
     no_cidr_address_parsing,
     no_xmpp_addr_domain_parsing,
     parse_urls_without_scheme,
+    parse_unicode_iocs,
     parse_all,
 ):
     """CLI interface for parsing observables."""
@@ -959,6 +1013,7 @@ def cli_find_iocs(
         parse_address_from_cidr=not no_cidr_address_parsing,
         parse_domain_name_from_xmpp_address=not no_xmpp_addr_domain_parsing,
         parse_urls_without_scheme=parse_urls_without_scheme,
+        parse_unicode_iocs=parse_unicode_iocs,
         included_ioc_types=included_ioc_types,
     )
     ioc_string = json.dumps(iocs, indent=4, sort_keys=True)
@@ -974,6 +1029,7 @@ def find_iocs(
     parse_address_from_cidr: bool = True,
     parse_domain_name_from_xmpp_address: bool = True,
     parse_urls_without_scheme: bool = True,
+    parse_unicode_iocs: bool = False,
     included_ioc_types: Iterable[str] | None = None,
 ) -> IndicatorData:
     """Find observables (a.k.a. indicators of compromise) in the given text.
@@ -993,6 +1049,12 @@ def find_iocs(
             addresses. Only applicable when ``"domains"`` is in ``included_ioc_types``.
         parse_urls_without_scheme: Whether to parse URLs without a scheme. Only applicable
             when ``"urls"`` or ``"urls_complete"`` is in ``included_ioc_types``.
+        parse_unicode_iocs: Whether to allow non-ASCII (Unicode) characters in domain
+            labels. When ``True``, domains like ``warrıors.com`` are parsed (and likewise
+            the domain part of email, URL, and XMPP IOCs). Defaults to ``False`` so the
+            ASCII-only behaviour is unchanged unless explicitly opted into. The TLD
+            itself is always ASCII (IANA stores IDN TLDs in their ``xn--`` punycode
+            form), as are email/URL/XMPP local parts and URL paths.
         included_ioc_types: Collection of IOC type names to parse. If ``None``,
             the common default types are parsed (see ``DEFAULT_IOC_TYPES``). For
             the full list of parseable types, see ``SUPPORTED_IOC_TYPES``. When
@@ -1030,11 +1092,15 @@ def find_iocs(
 
     # urls
     if "urls" in included_ioc_types:
-        iocs["urls"] = parse_urls(text, parse_urls_without_scheme=parse_urls_without_scheme)
+        iocs["urls"] = parse_urls(
+            text, parse_urls_without_scheme=parse_urls_without_scheme, parse_unicode_iocs=parse_unicode_iocs
+        )
 
     # urls_complete
     if "urls_complete" in included_ioc_types:
-        iocs["urls_complete"] = parse_urls_complete(text, parse_urls_without_scheme=parse_urls_without_scheme)
+        iocs["urls_complete"] = parse_urls_complete(
+            text, parse_urls_without_scheme=parse_urls_without_scheme, parse_unicode_iocs=parse_unicode_iocs
+        )
 
     # TODO: clean this section up
     if not parse_domain_from_url and not parse_from_url_path:
@@ -1042,45 +1108,57 @@ def find_iocs(
         text = _remove_items(iocs.get("urls_complete", []), text)
     elif not parse_domain_from_url:
         text = _percent_decode_url(iocs.get("urls", []), text)
-        text = _remove_url_domain_name(iocs.get("urls", []), text)
+        text = _remove_url_domain_name(iocs.get("urls", []), text, parse_unicode_iocs=parse_unicode_iocs)
 
         text = _percent_decode_url(iocs.get("urls_complete", []), text)
-        text = _remove_url_domain_name(iocs.get("urls_complete", []), text)
+        text = _remove_url_domain_name(iocs.get("urls_complete", []), text, parse_unicode_iocs=parse_unicode_iocs)
     elif not parse_from_url_path:
         text = _percent_decode_url(iocs.get("urls", []), text)
-        text = _remove_url_paths(iocs.get("urls", []), text)
+        text = _remove_url_paths(iocs.get("urls", []), text, parse_unicode_iocs=parse_unicode_iocs)
 
         text = _percent_decode_url(iocs.get("urls_complete", []), text)
-        text = _remove_url_paths(iocs.get("urls_complete", []), text)
+        text = _remove_url_paths(iocs.get("urls_complete", []), text, parse_unicode_iocs=parse_unicode_iocs)
     else:
         text = _percent_decode_url(iocs.get("urls", []), text)
         text = _percent_decode_url(iocs.get("urls_complete", []), text)
 
     # xmpp addresses
     if "xmpp_addresses" in included_ioc_types:
-        iocs["xmpp_addresses"] = parse_xmpp_addresses(text)
+        iocs["xmpp_addresses"] = parse_xmpp_addresses(text, parse_unicode_iocs=parse_unicode_iocs)
 
     if "domains" in included_ioc_types and not parse_domain_name_from_xmpp_address:
-        xmpp_addresses = _get_items(iocs, "xmpp_addresses", parse_xmpp_addresses, text)
+        xmpp_addresses = _get_items(
+            iocs, "xmpp_addresses", parse_xmpp_addresses, text, parse_unicode_iocs=parse_unicode_iocs
+        )
         text = _remove_items(xmpp_addresses, text)
     # even if we want to parse domain names from the xmpp_address,
     # we don't want them also being caught as email addresses so we'll remove everything before the `@`
     elif "email_addresses_complete" in included_ioc_types or "email_addresses" in included_ioc_types:
-        xmpp_addresses = _get_items(iocs, "xmpp_addresses", parse_xmpp_addresses, text)
+        xmpp_addresses = _get_items(
+            iocs, "xmpp_addresses", parse_xmpp_addresses, text, parse_unicode_iocs=parse_unicode_iocs
+        )
         text = _remove_xmpp_local_part(xmpp_addresses, text)
 
     if "email_addresses_complete" in included_ioc_types or "email_addresses" in included_ioc_types:
-        text = _remove_url_userinfo(iocs.get("urls_complete", []), text)
+        text = _remove_url_userinfo(iocs.get("urls_complete", []), text, parse_unicode_iocs=parse_unicode_iocs)
 
     # complete email addresses
     if "email_addresses_complete" in included_ioc_types:
-        iocs["email_addresses_complete"] = parse_complete_email_addresses(text)
+        iocs["email_addresses_complete"] = parse_complete_email_addresses(text, parse_unicode_iocs=parse_unicode_iocs)
     if "email_addresses" in included_ioc_types:
-        iocs["email_addresses"] = parse_email_addresses(text)
+        iocs["email_addresses"] = parse_email_addresses(text, parse_unicode_iocs=parse_unicode_iocs)
 
     if not parse_domain_from_email_address:
-        email_addresses_complete = _get_items(iocs, "email_addresses_complete", parse_complete_email_addresses, text)
-        email_addresses = _get_items(iocs, "email_addresses", parse_email_addresses, text)
+        email_addresses_complete = _get_items(
+            iocs,
+            "email_addresses_complete",
+            parse_complete_email_addresses,
+            text,
+            parse_unicode_iocs=parse_unicode_iocs,
+        )
+        email_addresses = _get_items(
+            iocs, "email_addresses", parse_email_addresses, text, parse_unicode_iocs=parse_unicode_iocs
+        )
 
         text = _remove_items(email_addresses_complete, text)
         text = _remove_items(email_addresses, text)
@@ -1170,7 +1248,7 @@ def find_iocs(
 
     # domains
     if "domains" in included_ioc_types:
-        iocs["domains"] = parse_domain_names(text)
+        iocs["domains"] = parse_domain_names(text, parse_unicode_iocs=parse_unicode_iocs)
 
     # ip addresses
     if "ipv4s" in included_ioc_types:
@@ -1251,8 +1329,9 @@ def find_iocs(
                 parse_urls,
                 text,
                 parse_urls_without_scheme=parse_urls_without_scheme,
+                parse_unicode_iocs=parse_unicode_iocs,
             )
-            text = _remove_url_paths(urls, text)
+            text = _remove_url_paths(urls, text, parse_unicode_iocs=parse_unicode_iocs)
 
         iocs["file_paths"] = parse_file_paths(text)
 

--- a/ioc_finder/ioc_grammars.py
+++ b/ioc_finder/ioc_grammars.py
@@ -1,5 +1,7 @@
 import copy
+import functools
 import re
+from types import SimpleNamespace
 
 from pyparsing import (
     CaselessLiteral,
@@ -51,17 +53,8 @@ label = Word(init_chars=alphanums + "_", body_chars=alphanums + "-_", max=63)
 # walk in `parse_domain_names`).
 TLD_SET = frozenset(t.lower() for t in tlds)
 domain_tld = one_of(tlds, caseless=True)
-# Equivalent to `OneOrMore(label + ("." + FollowedBy(Word(alphanums + "-_"))))`
-# but as a single Regex so pyparsing isn't paying OneOrMore + FollowedBy +
-# Word per label. The `{0,62}` body cap mirrors `label`'s `max=63`, and the
-# trailing `(?=...)` mirrors the FollowedBy that ensures each `.` is followed
-# by another label-valid character (so `domain_tld` runs against a real label
-# start rather than `.`-then-end-of-input). Used inside `domain_name` only;
-# `label` is still used standalone elsewhere.
-domain_labels = Regex(r"(?:[A-Za-z0-9_][A-Za-z0-9_-]{0,62}\.)+(?=[A-Za-z0-9_-])")
-domain_name = (
-    alphanum_word_start + Combine(domain_labels("domain_labels") + domain_tld("tld")) + alphanum_word_end
-).set_parse_action(pyparsing_common.downcase_tokens)
+# `domain_name` (and everything built on it) is defined in `_build_domain_layer`
+# below, after the IP-address grammars it embeds.
 
 ipv4_section = (
     Word(nums, as_keyword=True, max=3)
@@ -95,76 +88,174 @@ ipv6_address = (
     + ipv6_word_end
 )
 
-complete_email_comment = Regex(r"\([a-zA-Z0-9]+\)")
-# the complete_email_local_part grammar ignores the fact that characters like <<<(),:;<>@[\] >>>
-# are possible in a quoted complete_email_local_part
-# (and the double-quotes and backslash should be preceded by a backslash)
-complete_email_local_part = Combine(
-    Optional(complete_email_comment)("email_address_start_comment")
-    + OneOrMore(MatchFirst([Word(alphanums + "!#$%&'*+-/=?^_`{|}~." + '"'), CaselessLiteral("\\@")]))
-    + Optional(complete_email_comment)("email_address_end_comment")
-)
-complete_email_address = Combine(
-    complete_email_local_part("email_address_local_part")
-    + "@"
-    + Or([domain_name, "[" + ipv4_address + "]", "[IPv6:" + ipv6_address + "]"])("email_address_domain")
-)
+# --- domain / email / URL / XMPP grammar layer -------------------------------
+# Everything below hangs off `domain_name`, and the only thing the
+# `parse_unicode_iocs` option (find_iocs(..., parse_unicode_iocs=True)) changes
+# is the set of characters allowed inside a domain label. `_build_domain_layer`
+# rebuilds the whole layer from one label pattern so the ASCII and Unicode
+# variants can't drift: the ASCII variant is unpacked into module globals
+# immediately (preserving the historical names) and `unicode_domain_layer()`
+# returns the Unicode one.
 
-email_local_part = Word(alphanums, body_chars=alphanums + "+-_.").set_parse_action(pyparsing_common.downcase_tokens)
-email_address = alphanum_word_start + Combine(
-    email_local_part("email_address_local_part")
-    + "@"
-    + Or([domain_name, "[" + ipv4_address + "]", "[IPv6:" + ipv6_address + "]"])("email_address_domain")
-)
+# `domain_labels` is equivalent to `OneOrMore(label + ("." + FollowedBy(...)))`
+# collapsed into a single Regex (so pyparsing isn't paying OneOrMore +
+# FollowedBy + Word per label). The `{0,62}` body cap mirrors `label`'s
+# `max=63`, and the trailing `(?=...)` ensures each `.` is followed by another
+# label-valid character so `domain_tld` runs against a real label start rather
+# than `.`-then-end-of-input.
+# ASCII labels: alnum + "_" (init) / alnum + "_-" (body), mirroring `label`.
+_ASCII_DOMAIN_LABELS_PATTERN = r"(?:[A-Za-z0-9_][A-Za-z0-9_-]{0,62}\.)+(?=[A-Za-z0-9_-])"
+# Unicode labels: `\w` is Unicode-aware (letters of any script + digits + "_")
+# and `[\w-]` replaces `[A-Za-z0-9_-]` for label bodies. The TLD itself stays
+# ASCII — the IANA list stores IDN TLDs in their `xn--` punycode form.
+_UNICODE_DOMAIN_LABELS_PATTERN = r"(?:\w[\w-]{0,62}\.)+(?=[\w-])"
 
-url_scheme = one_of(schemes, caseless=True)
-port = Word(":", nums, min=2)
-url_authority = Combine(Or([email_address, domain_name, ipv4_address, ipv6_address]) + Optional(port)("port"))
-url_userinfo_complete = Word(alphanums + "-._~!$&'()*+,;=:%")
-url_authority_complete = Combine(
-    Optional(url_userinfo_complete("url_userinfo") + "@")
-    + Or([domain_name, ipv4_address, ipv6_address])("url_host")
-    + Optional(port)("port")
-)
-# The url_path_word characters are taken from https://www.ietf.org/rfc/rfc3986.txt
-# (of particular interest is "Appendix A.  Collected ABNF for URI", which defines
-# pchar = unreserved / pct-encoded / sub-delims / ":" / "@").
-# url_path_word omits "," and "@" to reduce false positives in the simple grammar;
-# url_path_word_complete includes the full pchar set for spec-faithful matching.
-url_path_word = Word(alphanums + "-._~!$&'()*+;=:%")
-url_path_word_complete = Word(alphanums + "-._~!$&'()*+,;=:@%")
-url_path = Combine(OneOrMore(MatchFirst([url_path_word, Literal("/")])))
-url_path_complete = Combine(OneOrMore(MatchFirst([url_path_word_complete, Literal("/")])))
-url_query = Word(printables, exclude_chars="#\"']")
-url_fragment = Word(printables, exclude_chars="?\"']")
-url = alphanum_word_start + Combine(
-    url_scheme("url_scheme")
-    + "://"
-    + url_authority("url_authority")
-    + Optional(Combine("/" + Optional(url_path)))("url_path")
-    + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
-)
-url_complete = alphanum_word_start + Combine(
-    url_scheme("url_scheme")
-    + "://"
-    + url_authority_complete("url_authority")
-    + Optional(Combine("/" + Optional(url_path_complete)))("url_path")
-    + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
-)
-# Issue #244: `scheme_less_url[_complete]` now only matches URLs without a
-# scheme (the scheme-ful alternative has been dropped). `parse_urls` runs the
-# scheme-ful grammar first and masks each matched URL's character span before
-# running this grammar, so a scheme-ful URL never re-surfaces as a scheme-less
-# one and embedded URL paths/queries (e.g.
-# `https://shortener.com/?url=foo.com/bar`) do not surface twice either.
-scheme_less_url = alphanum_word_start + Combine(
-    Combine(url_authority("url_authority") + Combine("/" + Optional(url_path))("url_path"))
-    + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
-)
-scheme_less_url_complete = alphanum_word_start + Combine(
-    Combine(url_authority_complete("url_authority") + Combine("/" + Optional(url_path_complete))("url_path"))
-    + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
-)
+
+def _build_domain_layer(domain_labels_pattern: str) -> SimpleNamespace:
+    """Build `domain_name` and every email/URL/XMPP grammar that embeds it, using
+    `domain_labels_pattern` for the run of dot-separated labels before the TLD.
+    Called once for the ASCII pattern and once (cached) for the Unicode one; see
+    `unicode_domain_layer`."""
+    domain_labels = Regex(domain_labels_pattern)
+    domain_name = (
+        alphanum_word_start + Combine(domain_labels("domain_labels") + domain_tld("tld")) + alphanum_word_end
+    ).set_parse_action(pyparsing_common.downcase_tokens)
+
+    complete_email_comment = Regex(r"\([a-zA-Z0-9]+\)")
+    # the complete_email_local_part grammar ignores the fact that characters like <<<(),:;<>@[\] >>>
+    # are possible in a quoted complete_email_local_part
+    # (and the double-quotes and backslash should be preceded by a backslash)
+    complete_email_local_part = Combine(
+        Optional(complete_email_comment)("email_address_start_comment")
+        + OneOrMore(MatchFirst([Word(alphanums + "!#$%&'*+-/=?^_`{|}~." + '"'), CaselessLiteral("\\@")]))
+        + Optional(complete_email_comment)("email_address_end_comment")
+    )
+    complete_email_address = Combine(
+        complete_email_local_part("email_address_local_part")
+        + "@"
+        + Or([domain_name, "[" + ipv4_address + "]", "[IPv6:" + ipv6_address + "]"])("email_address_domain")
+    )
+
+    email_local_part = Word(alphanums, body_chars=alphanums + "+-_.").set_parse_action(pyparsing_common.downcase_tokens)
+    email_address = alphanum_word_start + Combine(
+        email_local_part("email_address_local_part")
+        + "@"
+        + Or([domain_name, "[" + ipv4_address + "]", "[IPv6:" + ipv6_address + "]"])("email_address_domain")
+    )
+
+    url_scheme = one_of(schemes, caseless=True)
+    port = Word(":", nums, min=2)
+    url_authority = Combine(Or([email_address, domain_name, ipv4_address, ipv6_address]) + Optional(port)("port"))
+    url_userinfo_complete = Word(alphanums + "-._~!$&'()*+,;=:%")
+    url_authority_complete = Combine(
+        Optional(url_userinfo_complete("url_userinfo") + "@")
+        + Or([domain_name, ipv4_address, ipv6_address])("url_host")
+        + Optional(port)("port")
+    )
+    # The url_path_word characters are taken from https://www.ietf.org/rfc/rfc3986.txt
+    # (of particular interest is "Appendix A.  Collected ABNF for URI", which defines
+    # pchar = unreserved / pct-encoded / sub-delims / ":" / "@").
+    # url_path_word omits "," and "@" to reduce false positives in the simple grammar;
+    # url_path_word_complete includes the full pchar set for spec-faithful matching.
+    url_path_word = Word(alphanums + "-._~!$&'()*+;=:%")
+    url_path_word_complete = Word(alphanums + "-._~!$&'()*+,;=:@%")
+    url_path = Combine(OneOrMore(MatchFirst([url_path_word, Literal("/")])))
+    url_path_complete = Combine(OneOrMore(MatchFirst([url_path_word_complete, Literal("/")])))
+    url_query = Word(printables, exclude_chars="#\"']")
+    url_fragment = Word(printables, exclude_chars="?\"']")
+    url = alphanum_word_start + Combine(
+        url_scheme("url_scheme")
+        + "://"
+        + url_authority("url_authority")
+        + Optional(Combine("/" + Optional(url_path)))("url_path")
+        + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
+    )
+    url_complete = alphanum_word_start + Combine(
+        url_scheme("url_scheme")
+        + "://"
+        + url_authority_complete("url_authority")
+        + Optional(Combine("/" + Optional(url_path_complete)))("url_path")
+        + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
+    )
+    # Issue #244: `scheme_less_url[_complete]` now only matches URLs without a
+    # scheme (the scheme-ful alternative has been dropped). `parse_urls` runs the
+    # scheme-ful grammar first and masks each matched URL's character span before
+    # running this grammar, so a scheme-ful URL never re-surfaces as a scheme-less
+    # one and embedded URL paths/queries (e.g.
+    # `https://shortener.com/?url=foo.com/bar`) do not surface twice either.
+    scheme_less_url = alphanum_word_start + Combine(
+        Combine(url_authority("url_authority") + Combine("/" + Optional(url_path))("url_path"))
+        + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
+    )
+    scheme_less_url_complete = alphanum_word_start + Combine(
+        Combine(url_authority_complete("url_authority") + Combine("/" + Optional(url_path_complete))("url_path"))
+        + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
+    )
+
+    # see https://github.com/fhightower/ioc-finder/issues/18
+    xmpp_address = alphanum_word_start + Combine(
+        email_local_part("email_address_local_part") + "@" + domain_name("jabber_address_domain")
+    ).add_condition(lambda tokens: "jabber" in tokens[0].split("@")[-1] or "xmpp" in tokens[0].split("@")[-1])
+
+    return SimpleNamespace(
+        domain_name=domain_name,
+        complete_email_comment=complete_email_comment,
+        complete_email_local_part=complete_email_local_part,
+        complete_email_address=complete_email_address,
+        email_local_part=email_local_part,
+        email_address=email_address,
+        url_scheme=url_scheme,
+        port=port,
+        url_authority=url_authority,
+        url_userinfo_complete=url_userinfo_complete,
+        url_authority_complete=url_authority_complete,
+        url_path_word=url_path_word,
+        url_path_word_complete=url_path_word_complete,
+        url_path=url_path,
+        url_path_complete=url_path_complete,
+        url_query=url_query,
+        url_fragment=url_fragment,
+        url=url,
+        url_complete=url_complete,
+        scheme_less_url=scheme_less_url,
+        scheme_less_url_complete=scheme_less_url_complete,
+        xmpp_address=xmpp_address,
+    )
+
+
+_ascii_domain_layer = _build_domain_layer(_ASCII_DOMAIN_LABELS_PATTERN)
+domain_name = _ascii_domain_layer.domain_name
+complete_email_comment = _ascii_domain_layer.complete_email_comment
+complete_email_local_part = _ascii_domain_layer.complete_email_local_part
+complete_email_address = _ascii_domain_layer.complete_email_address
+email_local_part = _ascii_domain_layer.email_local_part
+email_address = _ascii_domain_layer.email_address
+url_scheme = _ascii_domain_layer.url_scheme
+port = _ascii_domain_layer.port
+url_authority = _ascii_domain_layer.url_authority
+url_userinfo_complete = _ascii_domain_layer.url_userinfo_complete
+url_authority_complete = _ascii_domain_layer.url_authority_complete
+url_path_word = _ascii_domain_layer.url_path_word
+url_path_word_complete = _ascii_domain_layer.url_path_word_complete
+url_path = _ascii_domain_layer.url_path
+url_path_complete = _ascii_domain_layer.url_path_complete
+url_query = _ascii_domain_layer.url_query
+url_fragment = _ascii_domain_layer.url_fragment
+url = _ascii_domain_layer.url
+url_complete = _ascii_domain_layer.url_complete
+scheme_less_url = _ascii_domain_layer.scheme_less_url
+scheme_less_url_complete = _ascii_domain_layer.scheme_less_url_complete
+xmpp_address = _ascii_domain_layer.xmpp_address
+
+
+@functools.lru_cache(maxsize=1)
+def unicode_domain_layer() -> SimpleNamespace:
+    """Return the domain/email/URL/XMPP grammar layer rebuilt with a Unicode-aware
+    domain-label character set, for find_iocs(..., parse_unicode_iocs=True). Built
+    once and cached; the returned namespace exposes the same attribute names as the
+    module-level ASCII grammars it mirrors."""
+    return _build_domain_layer(_UNICODE_DOMAIN_LABELS_PATTERN)
+
 
 # this allows for matching file hashes preceeded with an 'x' or 'X'...
 # see https://github.com/fhightower/ioc-finder/issues/41
@@ -342,10 +433,8 @@ bitcoin_address = (
 
 monero_address = alphanum_word_start + Regex("4[0-9AB][1-9A-HJ-NP-Za-km-z]{93}") + alphanum_word_end
 
-# see https://github.com/fhightower/ioc-finder/issues/18
-xmpp_address = alphanum_word_start + Combine(
-    email_local_part("email_address_local_part") + "@" + domain_name("jabber_address_domain")
-).add_condition(lambda tokens: "jabber" in tokens[0].split("@")[-1] or "xmpp" in tokens[0].split("@")[-1])
+# `xmpp_address` is defined in the domain/email/URL/XMPP grammar layer above
+# (see `_build_domain_layer`) so it tracks the `parse_unicode_iocs` label set.
 
 # the mac address grammar was developed from https://en.wikipedia.org/wiki/MAC_address#Notational_conventions
 # handles xx:xx:xx:xx:xx:xx or xx-xx-xx-xx-xx-xx

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,4 +1,5 @@
 import concurrent.futures
+import functools
 
 from ioc_finder import find_iocs
 
@@ -14,3 +15,19 @@ def test_nested_concurrency():
     assert "example.com" in results[2]["domains"]
     assert "example.org" in results[2]["domains"]
     assert results[2]["urls"] == ["https://example.org/test/bingo.php"]
+
+
+def test_unicode_layer_concurrency():
+    """The Unicode grammar layer (`ioc_grammars.unicode_domain_layer()`) is
+    module-shared just like the ASCII grammars — exercise it from multiple
+    threads (including its lazy first build) to guard against state leakage."""
+    texts = ["warrıors.com", "foo bar bang buzz", "an example.com and https://exämple.org/test/bingo.php"]
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        results = list(executor.map(functools.partial(find_iocs, parse_unicode_iocs=True), texts))
+
+    assert results[0]["domains"] == ["warrıors.com"]
+    assert results[1]["domains"] == []
+    assert "example.com" in results[2]["domains"]
+    assert "exämple.org" in results[2]["domains"]
+    assert results[2]["urls"] == ["https://exämple.org/test/bingo.php"]

--- a/tests/test_parsing_functions.py
+++ b/tests/test_parsing_functions.py
@@ -1,7 +1,10 @@
 """Make sure that the parsing functions for specific functions are imported properly."""
 
+import pytest
+from pyparsing import ParseException
+
 from ioc_finder import parse_urls
-from ioc_finder.ioc_finder import _url_candidate_spans
+from ioc_finder.ioc_finder import _parse_url, _remove_url_userinfo, _url_candidate_spans
 
 
 def test_url_parsing_func():
@@ -18,3 +21,16 @@ def test_url_candidate_spans_skip_markers_inside_expanded_span():
         (0, first),
         (len(first) + 1, second),
     ]
+
+
+def test_parse_url_raises_on_unparseable_input():
+    """`_parse_url` falls through all four URL grammars and raises."""
+    with pytest.raises(ParseException, match="could not parse URL"):
+        _parse_url("not a url at all")
+
+
+def test_remove_url_userinfo_skips_unparseable_url():
+    """A 'URL' that neither complete grammar can parse is skipped and the
+    text is returned unchanged."""
+    text = "some text"
+    assert _remove_url_userinfo(["not a url at all"], text) == text

--- a/tests/test_unicode_iocs.py
+++ b/tests/test_unicode_iocs.py
@@ -47,6 +47,14 @@ def test_unicode_boundary_semantics():
     assert parse_domain_names("see example.com中 now") == ["example.com"]
     assert parse_domain_names("see example.com中 now", parse_unicode_iocs=True) == []
 
+    # Scope: the rule applies to bare domains only. Email/URL/XMPP grammars
+    # keep ASCII word boundaries even in the Unicode layer, so Unicode mode
+    # never removes an email/URL/XMPP match that ASCII mode finds.
+    assert parse_email_addresses("bob@example.com中") == ["bob@example.com"]
+    assert parse_email_addresses("bob@example.com中", parse_unicode_iocs=True) == ["bob@example.com"]
+    assert parse_urls("https://example.com中/path", parse_unicode_iocs=True) == ["https://example.com"]
+    assert parse_xmpp_addresses("a@jabber.example.com中", parse_unicode_iocs=True) == ["a@jabber.example.com"]
+
 
 def test_unicode_email_address():
     text = f"reach out to bob@{UNICODE_DOMAIN} please"

--- a/tests/test_unicode_iocs.py
+++ b/tests/test_unicode_iocs.py
@@ -1,0 +1,143 @@
+"""Tests for the ``parse_unicode_iocs`` option (https://github.com/fhightower/ioc-finder/issues/298)."""
+
+from ioc_finder import find_iocs
+from ioc_finder.ioc_finder import (
+    parse_complete_email_addresses,
+    parse_domain_names,
+    parse_email_addresses,
+    parse_urls,
+    parse_xmpp_addresses,
+)
+
+# `ı` is U+0131 LATIN SMALL LETTER DOTLESS I — the character from the issue.
+UNICODE_DOMAIN = "warrıors.com"
+
+
+def test_unicode_domain_not_parsed_by_default():
+    # Without the option, a Unicode label is not recognised: the ASCII candidate
+    # regex starts the domain after the non-ASCII char, so only the ASCII tail
+    # surfaces (pre-existing behaviour, kept for backwards compatibility —
+    # see https://github.com/fhightower/ioc-finder/issues/298).
+    assert find_iocs("warrıors[dot]com")["domains"] == ["ors.com"]
+    assert parse_domain_names("warrıors.com") == ["ors.com"]
+
+
+def test_unicode_domain_parsed_when_opted_in():
+    assert find_iocs("warrıors[dot]com", parse_unicode_iocs=True)["domains"] == [UNICODE_DOMAIN]
+    assert find_iocs(f"see {UNICODE_DOMAIN} for details", parse_unicode_iocs=True)["domains"] == [UNICODE_DOMAIN]
+    assert parse_domain_names(f"a {UNICODE_DOMAIN} b", parse_unicode_iocs=True) == [UNICODE_DOMAIN]
+
+
+def test_unicode_domain_across_scripts():
+    for domain in ("exämple.com", "пример.com", "δοκιμή.com", "中文.com"):
+        assert parse_domain_names(f"go to {domain} now", parse_unicode_iocs=True) == [domain]
+
+
+def test_unicode_domain_picks_rightmost_tld():
+    # Same right-to-left TLD walk as the ASCII path.
+    assert parse_domain_names("föö.com.invalid", parse_unicode_iocs=True) == ["föö.com"]
+
+
+def test_unicode_boundary_semantics():
+    """In Unicode mode, a non-ASCII letter is a word character: `example.com中`
+    is one word (no domain), the same way `example.comX` is one word in ASCII
+    mode. ASCII mode instead treats the `中` as a boundary and reports
+    `example.com`. Deliberate semantic difference — see the comment on
+    `_DOMAIN_CANDIDATE_RE_UNICODE`."""
+    assert parse_domain_names("see example.com中 now") == ["example.com"]
+    assert parse_domain_names("see example.com中 now", parse_unicode_iocs=True) == []
+
+
+def test_unicode_email_address():
+    text = f"reach out to bob@{UNICODE_DOMAIN} please"
+    assert parse_email_addresses(text, parse_unicode_iocs=True) == [f"bob@{UNICODE_DOMAIN}"]
+    assert parse_complete_email_addresses(text, parse_unicode_iocs=True) == [f"bob@{UNICODE_DOMAIN}"]
+
+    iocs = find_iocs(text, parse_unicode_iocs=True, included_ioc_types=["email_addresses", "domains"])
+    assert iocs["email_addresses"] == [f"bob@{UNICODE_DOMAIN}"]
+    assert iocs["domains"] == [UNICODE_DOMAIN]
+
+
+def test_unicode_email_not_parsed_by_default():
+    text = f"bob@{UNICODE_DOMAIN}"
+    assert parse_email_addresses(text) == []
+
+
+def test_unicode_url():
+    text = f"visit https://{UNICODE_DOMAIN}/path?q=1#frag now"
+    assert parse_urls(text, parse_unicode_iocs=True) == [f"https://{UNICODE_DOMAIN}/path?q=1#frag"]
+
+    # The domain is also pulled out of the URL.
+    iocs = find_iocs(text, parse_unicode_iocs=True, included_ioc_types=["urls", "domains"])
+    assert iocs["urls"] == [f"https://{UNICODE_DOMAIN}/path?q=1#frag"]
+    assert iocs["domains"] == [UNICODE_DOMAIN]
+
+
+def test_unicode_url_without_scheme():
+    text = f"{UNICODE_DOMAIN}/some/path"
+    assert parse_urls(text, parse_unicode_iocs=True) == [text]
+
+
+def test_unicode_scheme_ful_url_not_double_counted():
+    """The two-pass URL scan (scheme-ful first, then masked scheme-less — see
+    issue #244) must also hold in Unicode mode: one URL in, one URL out."""
+    text = f"hit https://{UNICODE_DOMAIN}/path today"
+    assert parse_urls(text, parse_unicode_iocs=True) == [f"https://{UNICODE_DOMAIN}/path"]
+
+
+def test_unicode_url_domain_not_double_counted_as_email():
+    # `_remove_url_userinfo` has to be able to re-parse a Unicode URL.
+    text = f"http://user@{UNICODE_DOMAIN}/x"
+    iocs = find_iocs(text, parse_unicode_iocs=True, included_ioc_types=["urls_complete", "email_addresses"])
+    assert iocs["urls_complete"] == [f"http://user@{UNICODE_DOMAIN}/x"]
+    assert iocs["email_addresses"] == []
+
+
+def test_unicode_url_domain_removal_branch():
+    """`parse_domain_from_url=False` exercises `_remove_url_domain_name` →
+    `_parse_url`, which must re-parse a Unicode URL with the Unicode grammars."""
+    text = f"see https://{UNICODE_DOMAIN}/path now"
+    iocs = find_iocs(
+        text,
+        parse_unicode_iocs=True,
+        parse_domain_from_url=False,
+        included_ioc_types=["urls", "domains"],
+    )
+    assert iocs["urls"] == [f"https://{UNICODE_DOMAIN}/path"]
+    assert iocs["domains"] == []
+
+
+def test_unicode_xmpp_address():
+    text = f"alice@jabber.{UNICODE_DOMAIN}"
+    assert parse_xmpp_addresses(text, parse_unicode_iocs=True) == [text]
+    iocs = find_iocs(text, parse_unicode_iocs=True, included_ioc_types=["xmpp_addresses"])
+    assert iocs["xmpp_addresses"] == [text]
+
+
+def test_unicode_option_does_not_affect_ascii_results():
+    text = "Email bob@example.com about https://example.org/foo and 1.2.3.4 (cve-2020-1234)."
+    assert find_iocs(text) == find_iocs(text, parse_unicode_iocs=True)
+
+
+def test_tld_stays_ascii():
+    # IDN TLDs live in the IANA list in punycode form, so a non-ASCII string in
+    # the TLD position is not a domain even with the option enabled.
+    assert parse_domain_names("example.cöm", parse_unicode_iocs=True) == []
+
+
+def test_cli_unicode_flag():
+    import json
+
+    from click.testing import CliRunner
+
+    from ioc_finder.ioc_finder import cli_find_iocs
+
+    runner = CliRunner()
+    result = runner.invoke(cli_find_iocs, ["--parse_unicode_iocs", f"go to {UNICODE_DOMAIN}"])
+    assert result.exit_code == 0
+    assert json.loads(result.output)["domains"] == [UNICODE_DOMAIN]
+
+    # Without the flag the Unicode label is not recognised.
+    result = runner.invoke(cli_find_iocs, [f"go to {UNICODE_DOMAIN}"])
+    assert result.exit_code == 0
+    assert json.loads(result.output)["domains"] == ["ors.com"]


### PR DESCRIPTION
## Changes

- Added a `parse_unicode_iocs` keyword to `find_iocs` (default `False`) and a `--parse_unicode_iocs` CLI flag. When enabled, domain labels may contain non-ASCII (Unicode) characters — e.g. `warrıors.com` (dotless `ı`) is now parsed, as is the domain part of email, URL, and XMPP IOCs.
- Refactored the domain/email/URL/XMPP grammar layer in `ioc_grammars.py` into a single `_build_domain_layer(domain_labels_pattern)` builder: the ASCII variant is unpacked into the historical module-level names and the Unicode variant is exposed via the cached `unicode_domain_layer()`, so the two cannot drift.
- Added Unicode variants of the domain/email/XMPP candidate prefilter regexes (`_DOMAIN_CANDIDATE_RE_UNICODE`, etc.). In Unicode mode, non-ASCII letters count as word characters at boundaries (`example.com中` yields no domain, mirroring `example.comX` in ASCII mode) — a deliberate, tested semantic difference.
- Threaded `parse_unicode_iocs` through `find_iocs`, the `parse_*` helpers, and the URL-rewriting helpers (`_parse_url`, `_remove_url_domain_name`, `_remove_url_paths`, `_remove_url_userinfo`) via a small `_domain_grammars()` selector, following the current two-pass scheme-ful/scheme-less URL scan from #244.
- TLDs stay ASCII (IANA stores internationalized TLDs in their `xn--` punycode form); email/URL/XMPP local parts and URL paths also stay ASCII.
- Added a Unicode-layer case to the concurrency state-leak test and direct tests for `_parse_url`'s failure path and `_remove_url_userinfo`'s skip branch.
- Updated `docs/quick-start.md` and `CHANGELOG.md`.

Fixes #298