### PR TITLE
Fix user-agent boundary so trailing colon-prefixed token is not absorbed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Fixed
 
 - `urls_complete` now accepts `@` in URL paths, matching the RFC 3986 `pchar` definition (e.g. `https://example.com/users/@alice` is now captured in full).
+- `parse_user_agents` no longer absorbs a trailing token like ` TLP` from input such as `Mozilla/4.0 (...) TLP:RED`. A bare (version-less) platform token must not be immediately followed by `:`. Versioned platforms (e.g. `Chrome/91.0`) are unaffected. ([#227](https://github.com/fhightower/ioc-finder/issues/227))
 
 ### Added
 

--- a/ioc_finder/ioc_grammars.py
+++ b/ioc_finder/ioc_grammars.py
@@ -375,7 +375,12 @@ user_agent_details = Regex(r"\(.+?\)")
 user_agent_platform = Combine(
     alphanum_word_start
     + Regex(r"[a-zA-Z]{2,}/?").add_condition(lambda tokens: tokens[0].lower().strip("/") != "mozilla")
-    + Optional(user_agent_platform_version)
+    # A platform either has a numeric version, or is a bare token that must not be
+    # immediately followed by ":". Without that constraint a token like "TLP" in
+    # "...) TLP:RED" gets absorbed into the user agent. The MatchFirst tries the
+    # version first so platforms with versions (e.g. "Chrome/91.0") still match
+    # cleanly even when they happen to abut a colon. See issue #227.
+    + (user_agent_platform_version | NotAny(":"))
 )
 user_agent = Combine(
     user_agent_start + user_agent_details + ZeroOrMore(user_agent_platform + Optional(user_agent_details)),

--- a/tests/find_iocs_cases/feature__included_ioc_types.py
+++ b/tests/find_iocs_cases/feature__included_ioc_types.py
@@ -40,9 +40,7 @@ IOC_EXAMPLES = {
         "496aKKdqF1xQSSEzw7wNrkZkDUsCD5cSmNCfVhVgEps52WERBcLDGzdF5UugmFoHMm9xRJdewvK2TFfAJNwEV25rTcVF5Vp"
     ],
     "mac_addresses": ["AA-F2-C9-A6-B3-4F"],
-    "user_agents": [
-        "Mozilla/4.0 (compatible; MSIE 7.0b; Windows NT 5.1; .NET CLR 1.1.4322; InfoPath.1) TLP"
-    ],  # I don't like this parsing... I've ticketed this for improvement here: https://github.com/fhightower/ioc-finder/issues/227
+    "user_agents": ["Mozilla/4.0 (compatible; MSIE 7.0b; Windows NT 5.1; .NET CLR 1.1.4322; InfoPath.1)"],
     "tlp_labels": ["TLP:RED"],
     "file_paths": ["~/foo/bar/abc.py"],
     "attack_mitigations": {"enterprise": ["M1036", "M1015"]},
@@ -57,7 +55,6 @@ all_ioc_text = all_ioc_text.replace(
     IOC_EXAMPLES["authentihashes"][0],  # type: ignore
     f"authentihash {IOC_EXAMPLES['authentihashes'][0]}",  # type: ignore
 )
-all_ioc_text = all_ioc_text.replace(IOC_EXAMPLES["user_agents"][0], IOC_EXAMPLES["user_agents"][0].rstrip(" TLP"))  # type: ignore
 # add the attack data
 all_ioc_text = all_ioc_text + " " + " ".join(IOC_EXAMPLES["attack_mitigations"]["enterprise"])  # type: ignore
 all_ioc_text = all_ioc_text + " " + " ".join(IOC_EXAMPLES["attack_tactics"]["pre_attack"])  # type: ignore

--- a/tests/test_ioc_finder.py
+++ b/tests/test_ioc_finder.py
@@ -427,6 +427,39 @@ def test_user_agents():
     assert "Mozilla/5.0 (Windows nt 6.1; wow64; rv:11.0) Gecko Firefox/11.0" in iocs["user_agents"]
 
 
+def test_user_agent_does_not_swallow_trailing_tlp_label():
+    """See https://github.com/fhightower/ioc-finder/issues/227."""
+    s = "Mozilla/4.0 (compatible; MSIE 7.0b; Windows NT 5.1; .NET CLR 1.1.4322; InfoPath.1) TLP:RED"
+    iocs = find_iocs(s)
+    assert iocs["user_agents"] == [
+        "Mozilla/4.0 (compatible; MSIE 7.0b; Windows NT 5.1; .NET CLR 1.1.4322; InfoPath.1)"
+    ]
+    assert iocs["tlp_labels"] == ["TLP:RED"]
+
+
+def test_user_agent_does_not_swallow_trailing_tlp_label_with_versioned_platform():
+    s = "Mozilla/5.0 (Windows NT 10.0) Gecko/20100101 Firefox/89.0 TLP:AMBER"
+    iocs = find_iocs(s)
+    assert iocs["user_agents"] == ["Mozilla/5.0 (Windows NT 10.0) Gecko/20100101 Firefox/89.0"]
+    assert iocs["tlp_labels"] == ["TLP:AMBER"]
+
+
+def test_user_agent_drops_bare_platform_followed_by_colon():
+    s = "Mozilla/5.0 (X11) Gecko Chrome HOST: example.com"
+    iocs = find_iocs(s)
+    assert iocs["user_agents"] == ["Mozilla/5.0 (X11) Gecko Chrome"]
+    assert "example.com" in iocs["domains"]
+
+
+def test_user_agent_keeps_versioned_platform_before_colon():
+    """A platform that carries a numeric version is kept even when the next
+    char is ':' (e.g. ':443' acting like a port number). The trailing ':443'
+    is not a valid platform start, so the user_agent loop exits cleanly."""
+    s = "Mozilla/5.0 (X11; Linux x86_64) Chrome/91.0:443/foo"
+    iocs = find_iocs(s)
+    assert iocs["user_agents"] == ["Mozilla/5.0 (X11; Linux x86_64) Chrome/91.0"]
+
+
 def test_monero_addresses():
     result = find_iocs(
         "496aKKdqF1xQSSEzw7wNrkZkDUsCD5cSmNCfVhVgEps52WERBcLDGzdF5UugmFoHMm9xRJdewvK2TFfAJNwEV25rTcVF5Vp"


### PR DESCRIPTION
A bare (version-less) UA platform token is now rejected if it is immediately followed by `:`. This stops inputs like `Mozilla/4.0 (...) TLP:RED` from absorbing ` TLP` into the user agent, while leaving versioned platforms (e.g. `Chrome/91.0`) untouched.

- `parse_user_agents` no longer pulls a trailing ` TLP` (or similar colon-prefixed token) into the user agent string
- `TLP:RED` and friends still surface in `tlp_labels` as before
- Removes the `rstrip(" TLP")` workaround from the included-types fixture that referenced this issue

Closes #227.