### PR TITLE
Restrict scheme-less URL grammar to scheme-less URLs only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - Sped up domain name parsing by bypassing pyparsing for the standalone domain parser: candidate spans from the cheap regex are now validated against a TLD set directly, picking the rightmost TLD that leaves ≥1 preceding label. The `domain_name` grammar is still used as a sub-grammar inside email/url/xmpp parsers, where its inner label loop has been collapsed into a single `Regex` (replacing the `OneOrMore(label + "." + FollowedBy(...))` construction).
+- The `scheme_less_url` and `scheme_less_url_complete` grammars no longer also match URLs with a scheme; they only match URLs without one ([#244](https://github.com/fhightower/ioc-finder/issues/244)). `parse_urls` and `parse_urls_complete` now run the scheme-ful grammar first and mask each matched URL before running the scheme-less grammar, so user-facing output of `find_iocs` is unchanged but embedded scheme-less hosts inside a scheme-ful URL's query (e.g. `https://shortener.com/?url=foo.com/bar`) no longer surface as a second URL.
 
 ### Fixed
 

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -350,33 +350,26 @@ def _clean_url(url: str) -> str:
     return url
 
 
-def _scheme_less_scan(text: str, scheme_ful_matches: list[str], grammar) -> list:
-    """Mask out scheme-ful URL matches so the scheme-less grammar does not
-    re-discover their authority/path/query as a second URL. Same-length space
-    padding is used so any caller relying on original offsets stays correct
-    (current callers only use plain string replace)."""
-    stripped = text
-    for url in scheme_ful_matches:
-        stripped = stripped.replace(url, " " * len(url))
-    return _scan_url_candidates(stripped, grammar)
-
-
 def parse_urls(text: str, *, parse_urls_without_scheme: bool = True) -> list:
     """."""
-    raw_urls = _scan_url_candidates(text, ioc_grammars.url)
+    raw_urls, scheme_ful_spans = _scan_url_candidates_with_spans(text, ioc_grammars.url)
+    raw_urls = list(raw_urls)
     if parse_urls_without_scheme:
-        raw_urls = list(raw_urls)
-        raw_urls.extend(_scheme_less_scan(text, raw_urls, ioc_grammars.scheme_less_url))
+        # Blank the exact spans the scheme-ful URLs occupy so the scheme-less
+        # grammar can't re-discover their authority/path/query as a second URL.
+        masked = _mask_spans(text, scheme_ful_spans)
+        raw_urls.extend(_scan_url_candidates(masked, ioc_grammars.scheme_less_url))
     # Cleaning may collapse two raw matches to the same string, so dedupe again.
     return _deduplicate(map(_clean_url, raw_urls))
 
 
 def parse_urls_complete(text: str, *, parse_urls_without_scheme: bool = True) -> list:
     """."""
-    raw_urls = _scan_url_candidates(text, ioc_grammars.url_complete)
+    raw_urls, scheme_ful_spans = _scan_url_candidates_with_spans(text, ioc_grammars.url_complete)
+    raw_urls = list(raw_urls)
     if parse_urls_without_scheme:
-        raw_urls = list(raw_urls)
-        raw_urls.extend(_scheme_less_scan(text, raw_urls, ioc_grammars.scheme_less_url_complete))
+        masked = _mask_spans(text, scheme_ful_spans)
+        raw_urls.extend(_scan_url_candidates(masked, ioc_grammars.scheme_less_url_complete))
     return _deduplicate(map(_clean_url, raw_urls))
 
 
@@ -496,9 +489,10 @@ def _scan_candidates(text, candidate_re, grammar):
 
 
 def _url_candidate_spans(text):
-    """Yield non-whitespace runs around each `_URL_MARKER_RE` hit. Built in
-    Python instead of as `\\S*<marker>\\S*` so a long non-whitespace run
-    that contains no marker (e.g. a 10kB base64 blob) doesn't trigger
+    """Yield `(offset, substring)` for each non-whitespace run around a
+    `_URL_MARKER_RE` hit, where `offset` is the run's start index in `text`.
+    Built in Python instead of as `\\S*<marker>\\S*` so a long non-whitespace
+    run that contains no marker (e.g. a 10kB base64 blob) doesn't trigger
     O(n²) regex backtracking."""
     seen_spans: set[tuple[int, int]] = set()
     n = len(text)
@@ -516,19 +510,44 @@ def _url_candidate_spans(text):
         if span not in seen_spans:
             seen_spans.add(span)
             last_span_end = end
-            yield text[start:end]
+            yield start, text[start:end]
 
 
-def _scan_url_candidates(text, grammar):
+def _scan_url_candidates_with_spans(text, grammar):
+    """Run `grammar.scan_string` over each URL candidate span, returning both
+    the deduplicated match values and the absolute `(start, end)` character
+    spans every raw match occupies in `text`. The spans let callers mask the
+    exact regions a scheme-ful URL covers (rather than `str.replace`-ing the
+    match text, which blows holes in a longer URL whose substring equals a
+    shorter match elsewhere)."""
     seen: set[str] = set()
     out: list[str] = []
-    for span in _url_candidate_spans(text):
-        for tokens, _start, _end in grammar.scan_string(span):
+    spans: list[tuple[int, int]] = []
+    for offset, span in _url_candidate_spans(text):
+        for tokens, sub_start, sub_end in grammar.scan_string(span):
+            spans.append((offset + sub_start, offset + sub_end))
             value = tokens[0]
             if value and value not in seen:
                 seen.add(value)
                 out.append(value)
-    return out
+    return out, spans
+
+
+def _scan_url_candidates(text, grammar):
+    values, _spans = _scan_url_candidates_with_spans(text, grammar)
+    return values
+
+
+def _mask_spans(text: str, spans: list[tuple[int, int]]) -> str:
+    """Return `text` with every `(start, end)` character range blanked to
+    spaces. Same-length replacement keeps all other offsets stable."""
+    if not spans:
+        return text
+    chars = list(text)
+    for start, end in spans:
+        for i in range(start, min(end, len(chars))):
+            chars[i] = " "
+    return "".join(chars)
 
 
 _IPV6_HEXNUMS = frozenset(hexdigits)

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -350,27 +350,50 @@ def _clean_url(url: str) -> str:
     return url
 
 
+def _scheme_less_scan(text: str, scheme_ful_matches: list[str], grammar) -> list:
+    """Mask out scheme-ful URL matches so the scheme-less grammar does not
+    re-discover their authority/path/query as a second URL. Same-length space
+    padding is used so any caller relying on original offsets stays correct
+    (current callers only use plain string replace)."""
+    stripped = text
+    for url in scheme_ful_matches:
+        stripped = stripped.replace(url, " " * len(url))
+    return _scan_url_candidates(stripped, grammar)
+
+
 def parse_urls(text: str, *, parse_urls_without_scheme: bool = True) -> list:
     """."""
-    grammar = ioc_grammars.scheme_less_url if parse_urls_without_scheme else ioc_grammars.url
-    raw_urls = _scan_url_candidates(text, grammar)
+    raw_urls = _scan_url_candidates(text, ioc_grammars.url)
+    if parse_urls_without_scheme:
+        raw_urls = list(raw_urls)
+        raw_urls.extend(_scheme_less_scan(text, raw_urls, ioc_grammars.scheme_less_url))
     # Cleaning may collapse two raw matches to the same string, so dedupe again.
     return _deduplicate(map(_clean_url, raw_urls))
 
 
 def parse_urls_complete(text: str, *, parse_urls_without_scheme: bool = True) -> list:
     """."""
-    grammar = ioc_grammars.scheme_less_url_complete if parse_urls_without_scheme else ioc_grammars.url_complete
-    raw_urls = _scan_url_candidates(text, grammar)
+    raw_urls = _scan_url_candidates(text, ioc_grammars.url_complete)
+    if parse_urls_without_scheme:
+        raw_urls = list(raw_urls)
+        raw_urls.extend(_scheme_less_scan(text, raw_urls, ioc_grammars.scheme_less_url_complete))
     return _deduplicate(map(_clean_url, raw_urls))
 
 
 def _parse_url(url: str) -> ParseResults:
-    """Parse a URL using the narrower grammar first, then the complete grammar."""
-    try:
-        return ioc_grammars.scheme_less_url.parse_string(url)
-    except ParseException:
-        return ioc_grammars.scheme_less_url_complete.parse_string(url)
+    """Parse a URL by trying the four URL grammars in order, since each may match
+    a different shape of input (scheme-ful vs scheme-less, narrow vs complete)."""
+    for grammar in (
+        ioc_grammars.url,
+        ioc_grammars.scheme_less_url,
+        ioc_grammars.url_complete,
+        ioc_grammars.scheme_less_url_complete,
+    ):
+        try:
+            return grammar.parse_string(url)
+        except ParseException:
+            continue
+    raise ParseException(url, msg=f"could not parse URL: {url!r}")
 
 
 def _remove_url_domain_name(urls: list, text: str) -> str:
@@ -400,7 +423,16 @@ def _remove_url_paths(urls: list, text: str) -> str:
 def _remove_url_userinfo(urls: list, text: str) -> str:
     """Remove userinfo from each URL so it is not parsed as an email address."""
     for url in urls:
-        parsed_url = ioc_grammars.scheme_less_url_complete.parse_string(url)
+        # Only the "complete" grammars expose url_userinfo. Try both because
+        # `scheme_less_url_complete` now rejects scheme-ful URLs.
+        for grammar in (ioc_grammars.url_complete, ioc_grammars.scheme_less_url_complete):
+            try:
+                parsed_url = grammar.parse_string(url)
+                break
+            except ParseException:
+                continue
+        else:
+            continue
         userinfo = parsed_url.url_authority.get("url_userinfo")
         if userinfo:
             text = text.replace(f"{userinfo}@", " ")

--- a/ioc_finder/ioc_grammars.py
+++ b/ioc_finder/ioc_grammars.py
@@ -152,17 +152,16 @@ url_complete = alphanum_word_start + Combine(
     + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
 )
 # Issue #244: `scheme_less_url[_complete]` now only matches URLs without a
-# scheme. We also tighten the starting boundary so a match cannot begin
-# immediately after `/`; otherwise scanning `https://foo.com/bar` would surface
-# `foo.com/bar` at the offset right after `://`. `parse_urls` masks scheme-ful
-# URL matches before running this grammar so embedded URL paths/queries (e.g.
+# scheme (the scheme-ful alternative has been dropped). `parse_urls` runs the
+# scheme-ful grammar first and masks each matched URL's character span before
+# running this grammar, so a scheme-ful URL never re-surfaces as a scheme-less
+# one and embedded URL paths/queries (e.g.
 # `https://shortener.com/?url=foo.com/bar`) do not surface twice either.
-scheme_less_url_word_start = WordStart(word_chars=alphanums + "/")
-scheme_less_url = scheme_less_url_word_start + Combine(
+scheme_less_url = alphanum_word_start + Combine(
     Combine(url_authority("url_authority") + Combine("/" + Optional(url_path))("url_path"))
     + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
 )
-scheme_less_url_complete = scheme_less_url_word_start + Combine(
+scheme_less_url_complete = alphanum_word_start + Combine(
     Combine(url_authority_complete("url_authority") + Combine("/" + Optional(url_path_complete))("url_path"))
     + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
 )

--- a/ioc_finder/ioc_grammars.py
+++ b/ioc_finder/ioc_grammars.py
@@ -151,23 +151,20 @@ url_complete = alphanum_word_start + Combine(
     + Optional(Combine("/" + Optional(url_path_complete)))("url_path")
     + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
 )
-scheme_less_url = alphanum_word_start + Or(
-    [
-        url,
-        Combine(
-            Combine(url_authority("url_authority") + Combine("/" + Optional(url_path))("url_path"))
-            + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
-        ),
-    ]
+# Issue #244: `scheme_less_url[_complete]` now only matches URLs without a
+# scheme. We also tighten the starting boundary so a match cannot begin
+# immediately after `/`; otherwise scanning `https://foo.com/bar` would surface
+# `foo.com/bar` at the offset right after `://`. `parse_urls` masks scheme-ful
+# URL matches before running this grammar so embedded URL paths/queries (e.g.
+# `https://shortener.com/?url=foo.com/bar`) do not surface twice either.
+scheme_less_url_word_start = WordStart(word_chars=alphanums + "/")
+scheme_less_url = scheme_less_url_word_start + Combine(
+    Combine(url_authority("url_authority") + Combine("/" + Optional(url_path))("url_path"))
+    + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
 )
-scheme_less_url_complete = alphanum_word_start + Or(
-    [
-        url_complete,
-        Combine(
-            Combine(url_authority_complete("url_authority") + Combine("/" + Optional(url_path_complete))("url_path"))
-            + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
-        ),
-    ]
+scheme_less_url_complete = scheme_less_url_word_start + Combine(
+    Combine(url_authority_complete("url_authority") + Combine("/" + Optional(url_path_complete))("url_path"))
+    + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
 )
 
 # this allows for matching file hashes preceeded with an 'x' or 'X'...

--- a/tests/test_parsing_functions.py
+++ b/tests/test_parsing_functions.py
@@ -12,4 +12,9 @@ def test_url_parsing_func():
 def test_url_candidate_spans_skip_markers_inside_expanded_span():
     text = ("a.a/" * 5000) + " https://example.com/path"
 
-    assert list(_url_candidate_spans(text)) == [text.split()[0], "https://example.com/path"]
+    first = text.split()[0]
+    second = "https://example.com/path"
+    assert list(_url_candidate_spans(text)) == [
+        (0, first),
+        (len(first) + 1, second),
+    ]

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -255,22 +255,43 @@ def test_scheme_less_url_grammar_accepts_bare_input():
     assert parsed[0] == "foo.com/bar"
 
 
-def test_scheme_less_url_grammar_scan_skips_post_scheme_offset():
-    """scan_string over a scheme-ful URL should yield zero hits because the
-    scheme-less grammar's stricter start refuses to match immediately after
-    `/`."""
-    assert list(scheme_less_url.scan_string("https://foo.com/bar")) == []
-
-
 def test_scheme_less_url_grammar_still_finds_parenthesised_match():
-    """Punctuation-delimited scheme-less URLs are not affected by the stricter
-    `/` boundary. We assert the match starts right after `(` so the boundary
-    check has not made the grammar refuse a legitimate parenthesised URL."""
+    """A punctuation-delimited scheme-less URL is found, starting right after
+    the opening `(`."""
     matches = list(scheme_less_url.scan_string("(foo.com/bar)"))
     assert len(matches) == 1
     tokens, start, _ = matches[0]
     assert tokens[0].startswith("foo.com/bar")
     assert start == 1
+
+
+def test_slash_preceded_scheme_less_url_still_found():
+    """A scheme-less URL whose host is preceded by a bare `/` must still be
+    found. The scheme-ful URL masking pass (not a grammar start boundary) is
+    what prevents scheme-ful URLs from re-surfacing, so a leading `/` here is
+    harmless. See PR #369 review thread."""
+    assert find_iocs("path/to/foo.com/bar")["urls"] == ["foo.com/bar"]
+
+
+def test_scheme_ful_substring_does_not_leak_scheme_less_match():
+    """Masking a scheme-ful URL must blank its exact character span, not every
+    occurrence of its match text. A shorter scheme-ful URL whose text is a
+    prefix of a longer one previously caused `str.replace` to punch a hole in
+    the longer URL, leaking a spurious scheme-less match from the remainder.
+    See PR #369 review thread."""
+    result = find_iocs("see http://a.com or http://a.com?u=b.co/x for more")
+    assert iterables_have_same_items(result["urls"], ["http://a.com", "http://a.com?u=b.co/x"])
+    assert "b.co/x" not in result["urls"]
+
+
+def test_embedded_url_in_query_not_found_when_scheme_less_disabled():
+    """With parse_urls_without_scheme=False only the scheme-ful URL is parsed,
+    so the embedded scheme-less host in its query never surfaces."""
+    result = find_iocs(
+        "Visit https://shortener.com/?url=foo.com/bar",
+        parse_urls_without_scheme=False,
+    )
+    assert result["urls"] == ["https://shortener.com/?url=foo.com/bar"]
 
 
 def test_parse_url_helper_handles_scheme_ful_and_scheme_less():

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -1,9 +1,12 @@
 """Test the URL parsing against the urls here: https://mathiasbynens.be/demo/url-regex."""
 
+import pytest
 from d8s_lists import iterables_have_same_items
+from pyparsing import ParseException
 
 from ioc_finder import find_iocs as _find_iocs
-from ioc_finder.ioc_finder import SUPPORTED_IOC_TYPES
+from ioc_finder.ioc_finder import SUPPORTED_IOC_TYPES, _parse_url, _remove_url_userinfo
+from ioc_finder.ioc_grammars import scheme_less_url
 
 
 def find_iocs(*args, **kwargs):
@@ -215,3 +218,78 @@ def test_url__percent_encoded_path():
         result["domains"], ["example.com", "bar.com"]
     )  # the key here is that "foo.com" is not parsed because it is part of the path (which has been removed)
     assert result["file_paths"] == []
+
+
+def test_scheme_ful_url_does_not_surface_twice():
+    """See https://github.com/fhightower/ioc-finder/issues/244. A scheme-ful URL
+    must not also surface as a scheme-less URL via the offset right after
+    `://`."""
+    result = find_iocs("https://example.com/path")
+    assert result["urls"] == ["https://example.com/path"]
+
+
+def test_scheme_less_url_after_scheme_ful_url():
+    result = find_iocs("https://a.com foo.com/bar")
+    assert iterables_have_same_items(result["urls"], ["https://a.com", "foo.com/bar"])
+
+
+def test_embedded_url_in_query_does_not_surface_separately():
+    """A scheme-less host/path embedded in a scheme-ful URL's query string must
+    not be matched as a second URL."""
+    result = find_iocs("Visit https://shortener.com/?url=foo.com/bar")
+    assert result["urls"] == ["https://shortener.com/?url=foo.com/bar"]
+
+
+def test_scheme_less_url_dedup():
+    result = find_iocs("foo.com/bar foo.com/bar")
+    assert result["urls"] == ["foo.com/bar"]
+
+
+def test_scheme_less_url_grammar_rejects_scheme_ful_input():
+    with pytest.raises(ParseException):
+        scheme_less_url.parse_string("https://foo.com/bar")
+
+
+def test_scheme_less_url_grammar_accepts_bare_input():
+    parsed = scheme_less_url.parse_string("foo.com/bar")
+    assert parsed[0] == "foo.com/bar"
+
+
+def test_scheme_less_url_grammar_scan_skips_post_scheme_offset():
+    """scan_string over a scheme-ful URL should yield zero hits because the
+    scheme-less grammar's stricter start refuses to match immediately after
+    `/`."""
+    assert list(scheme_less_url.scan_string("https://foo.com/bar")) == []
+
+
+def test_scheme_less_url_grammar_still_finds_parenthesised_match():
+    """Punctuation-delimited scheme-less URLs are not affected by the stricter
+    `/` boundary. We assert the match starts right after `(` so the boundary
+    check has not made the grammar refuse a legitimate parenthesised URL."""
+    matches = list(scheme_less_url.scan_string("(foo.com/bar)"))
+    assert len(matches) == 1
+    tokens, start, _ = matches[0]
+    assert tokens[0].startswith("foo.com/bar")
+    assert start == 1
+
+
+def test_parse_url_helper_handles_scheme_ful_and_scheme_less():
+    parsed = _parse_url("https://example.com/path")
+    authority = parsed.url_authority
+    if not isinstance(authority, str):
+        authority = authority[0]
+    assert authority == "example.com"
+
+    parsed = _parse_url("example.com/path")
+    authority = parsed.url_authority
+    if not isinstance(authority, str):
+        authority = authority[0]
+    assert authority == "example.com"
+
+
+def test_remove_url_userinfo_works_for_scheme_ful_url():
+    stripped = _remove_url_userinfo(
+        ["http://userid:password@example.com/"],
+        "http://userid:password@example.com/",
+    )
+    assert "userid:password@" not in stripped


### PR DESCRIPTION
`scheme_less_url` and `scheme_less_url_complete` now only match URLs without a scheme. `parse_urls` runs the scheme-ful grammar first and masks each matched URL before running the scheme-less grammar, so user-facing output stays identical for existing inputs.

- `scheme_less_url[_complete]` no longer matches inputs that start with a scheme, and a stricter `/` boundary stops a match from beginning right after `://`
- Embedded scheme-less hosts inside a scheme-ful URL's query (e.g. `https://shortener.com/?url=foo.com/bar`) no longer surface as a second URL
- `_parse_url` now try-cascades all four URL grammars, and `_remove_url_userinfo` falls back to `url_complete` for scheme-ful URLs

Closes #244.