### PR TITLE
Make scheme-less URL grammar match only scheme-less URLs (#244)

### DIFF
--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -9,9 +9,16 @@ from string import hexdigits
 
 import click
 import ioc_fanger
-from pyparsing import ParseException, ParseResults
+from pyparsing import Or, ParseException, ParseResults
 
 from ioc_finder import ioc_grammars
+
+# `scheme_less_url` and `scheme_less_url_complete` match only URLs without a
+# scheme. When the caller wants both kinds, combine them with the scheme'd
+# grammars under `Or` (longest-match) so a scheme'd URL like
+# "https://foo.com/x" is preferred over the scheme-less suffix "foo.com/x".
+_url_with_optional_scheme = Or([ioc_grammars.url, ioc_grammars.scheme_less_url])
+_url_complete_with_optional_scheme = Or([ioc_grammars.url_complete, ioc_grammars.scheme_less_url_complete])
 
 logger = logging.getLogger(__name__)
 
@@ -352,7 +359,7 @@ def _clean_url(url: str) -> str:
 
 def parse_urls(text: str, *, parse_urls_without_scheme: bool = True) -> list:
     """."""
-    grammar = ioc_grammars.scheme_less_url if parse_urls_without_scheme else ioc_grammars.url
+    grammar = _url_with_optional_scheme if parse_urls_without_scheme else ioc_grammars.url
     raw_urls = _scan_url_candidates(text, grammar)
     # Cleaning may collapse two raw matches to the same string, so dedupe again.
     return _deduplicate(map(_clean_url, raw_urls))
@@ -360,17 +367,26 @@ def parse_urls(text: str, *, parse_urls_without_scheme: bool = True) -> list:
 
 def parse_urls_complete(text: str, *, parse_urls_without_scheme: bool = True) -> list:
     """."""
-    grammar = ioc_grammars.scheme_less_url_complete if parse_urls_without_scheme else ioc_grammars.url_complete
+    grammar = _url_complete_with_optional_scheme if parse_urls_without_scheme else ioc_grammars.url_complete
     raw_urls = _scan_url_candidates(text, grammar)
     return _deduplicate(map(_clean_url, raw_urls))
 
 
 def _parse_url(url: str) -> ParseResults:
-    """Parse a URL using the narrower grammar first, then the complete grammar."""
-    try:
-        return ioc_grammars.scheme_less_url.parse_string(url)
-    except ParseException:
-        return ioc_grammars.scheme_less_url_complete.parse_string(url)
+    """Parse a URL using the narrower grammar first, then the complete grammar.
+    Tries scheme'd variants before scheme-less so a URL like "https://foo.com"
+    parses as a scheme'd URL rather than failing the scheme-less grammar."""
+    for grammar in (
+        ioc_grammars.url,
+        ioc_grammars.scheme_less_url,
+        ioc_grammars.url_complete,
+        ioc_grammars.scheme_less_url_complete,
+    ):
+        try:
+            return grammar.parse_string(url)
+        except ParseException:
+            continue
+    return ioc_grammars.scheme_less_url_complete.parse_string(url)
 
 
 def _remove_url_domain_name(urls: list, text: str) -> str:
@@ -400,7 +416,10 @@ def _remove_url_paths(urls: list, text: str) -> str:
 def _remove_url_userinfo(urls: list, text: str) -> str:
     """Remove userinfo from each URL so it is not parsed as an email address."""
     for url in urls:
-        parsed_url = ioc_grammars.scheme_less_url_complete.parse_string(url)
+        try:
+            parsed_url = ioc_grammars.url_complete.parse_string(url)
+        except ParseException:
+            parsed_url = ioc_grammars.scheme_less_url_complete.parse_string(url)
         userinfo = parsed_url.url_authority.get("url_userinfo")
         if userinfo:
             text = text.replace(f"{userinfo}@", " ")

--- a/ioc_finder/ioc_grammars.py
+++ b/ioc_finder/ioc_grammars.py
@@ -151,23 +151,13 @@ url_complete = alphanum_word_start + Combine(
     + Optional(Combine("/" + Optional(url_path_complete)))("url_path")
     + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
 )
-scheme_less_url = alphanum_word_start + Or(
-    [
-        url,
-        Combine(
-            Combine(url_authority("url_authority") + Combine("/" + Optional(url_path))("url_path"))
-            + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
-        ),
-    ]
+scheme_less_url = alphanum_word_start + Combine(
+    Combine(url_authority("url_authority") + Combine("/" + Optional(url_path))("url_path"))
+    + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
 )
-scheme_less_url_complete = alphanum_word_start + Or(
-    [
-        url_complete,
-        Combine(
-            Combine(url_authority_complete("url_authority") + Combine("/" + Optional(url_path_complete))("url_path"))
-            + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
-        ),
-    ]
+scheme_less_url_complete = alphanum_word_start + Combine(
+    Combine(url_authority_complete("url_authority") + Combine("/" + Optional(url_path_complete))("url_path"))
+    + (Optional(Combine("?" + url_query)("url_query")) & Optional(Combine("#" + url_fragment)("url_fragment")))
 )
 
 # this allows for matching file hashes preceeded with an 'x' or 'X'...


### PR DESCRIPTION
## Changes

- `scheme_less_url` and `scheme_less_url_complete` in `ioc_grammars.py` no longer include the scheme'd `url` / `url_complete` branch — they now match only URLs without a scheme, per issue #244
- Added module-level `_url_with_optional_scheme` and `_url_complete_with_optional_scheme` (`Or` of scheme'd + scheme-less) in `ioc_finder.py` so `parse_urls` / `parse_urls_complete` preserve their existing behavior of finding both kinds when `parse_urls_without_scheme=True`
- Updated `_parse_url` and `_remove_url_userinfo` to try scheme'd grammars first before falling back to scheme-less, since URLs passed to these helpers may have a scheme

Closes #244