### PR TITLE
Replace pyparsing with pure-Python validators for IPv4 and hex hash parsing

### DIFF
--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -81,8 +81,10 @@ _IPV6_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9:])(?:[0-9A-Fa-f]*:){2,}[0-9A-Fa
 # IPv4 candidates: four 1–3 digit groups separated by dots. The lookbehind
 # mirrors alphanum_word_start + WordStart("." + nums) — neither alphanumeric
 # nor '.' may precede. The trailing `(?!\.\S)` mirrors NotAny(r"\.\S") so a
-# fifth dotted segment ("1.2.3.4.5") is excluded; the grammar's per-octet
-# `<256` check still runs and rejects e.g. "999.1.1.1".
+# fifth dotted segment ("1.2.3.4.5") is excluded. The per-octet `<256` check
+# and the grammar's leading-zero normalization are applied by
+# `_normalized_ipv4` (pure Python — see parse_ipv4_addresses), which rejects
+# e.g. "999.1.1.1".
 _IPV4_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9.])(?:\d{1,3}\.){3}\d{1,3}(?![A-Za-z0-9])(?!\.\S)")
 
 # Hash candidates: a hex run of exactly 32/40/64 chars. The leading lookbehind
@@ -90,6 +92,10 @@ _IPV4_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9.])(?:\d{1,3}\.){3}\d{1,3}(?![A-
 # leading 'x'/'X' prefix is allowed (issue #41). The trailing lookahead mirrors
 # alphanum_word_end so a longer hex run isn't sliced into a shorter hash —
 # e.g. a 64-char run won't surface as an MD5 candidate.
+# NOTE: unlike the other candidate regexes these are *exact* mirrors of their
+# grammars, not supersets — parse_md5s/sha1s/sha256s/sha512s use them as the
+# sole validator via _scan_hash_candidates (no pyparsing pass). Keep them
+# byte-for-byte in sync with the md5/sha1/sha256/sha512 grammars.
 _MD5_CANDIDATE_RE = re.compile(r"(?<![A-WYZa-wyz0-9])[A-Fa-f0-9]{32}(?![A-Za-z0-9])")
 _SHA1_CANDIDATE_RE = re.compile(r"(?<![A-WYZa-wyz0-9])[A-Fa-f0-9]{40}(?![A-Za-z0-9])")
 _SHA256_CANDIDATE_RE = re.compile(r"(?<![A-WYZa-wyz0-9])[A-Fa-f0-9]{64}(?![A-Za-z0-9])")
@@ -551,9 +557,36 @@ def parse_domain_names(text, *, parse_unicode_iocs: bool = False):
     return out
 
 
+def _normalized_ipv4(span: str) -> str | None:
+    """Validate and normalize an IPv4 candidate span in pure Python, mirroring
+    ioc_grammars.ipv4_address: every octet must be < 256, and each is passed
+    through int() so leading zeros are stripped exactly like the grammar's
+    `str(int(...))` parse action ("001.002.003.004" -> "1.2.3.4"). The
+    candidate regexes guarantee four 1-3 digit groups and enforce the word
+    boundaries, so neither is re-checked here."""
+    octets = span.split(".")
+    for octet in octets:
+        if int(octet) > 255:
+            return None
+    return ".".join(str(int(octet)) for octet in octets)
+
+
 def parse_ipv4_addresses(text):
     """."""
-    return _scan_candidates(text, _IPV4_CANDIDATE_RE, ioc_grammars.ipv4_address)
+    # Pure-Python fast path (same asymmetry as parse_ipv6_addresses): the
+    # ipv4_address grammar's only transformation is the per-octet
+    # normalization reproduced by _normalized_ipv4, so skipping pyparsing
+    # preserves the output shape. Note dedup happens on the *normalized*
+    # value, matching the old grammar path ("1.2.3.4" and "01.2.3.4" are
+    # one result).
+    seen: set[str] = set()
+    out: list[str] = []
+    for m in _IPV4_CANDIDATE_RE.finditer(text):
+        value = _normalized_ipv4(m.group(0))
+        if value is not None and value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
 
 
 def _scan_candidates(text, candidate_re, grammar):
@@ -816,24 +849,45 @@ def parse_authentihashes_(text: str) -> list:
     return _deduplicate(ioc_grammars.authentihash.parse_string(a).hash[0] for a in full_authentihash_instances)
 
 
+def _scan_hash_candidates(text, candidate_re):
+    """Pure-Python fast path for the fixed-length hex hash types. Unlike the
+    other candidate regexes (which are deliberate supersets of their grammars),
+    the md5/sha1/sha256/sha512 candidate regexes are *exact* mirrors: same hex
+    charset, exact length, same word-boundary rules — and the grammars' only
+    parse action is downcasing. So the lowercased regex match IS the grammar
+    output and pyparsing can be skipped entirely. If a hash grammar in
+    ioc_grammars ever grows a rule its candidate regex doesn't mirror, these
+    parsers must go back through _scan_candidates. (parse_imphashes_ /
+    parse_authentihashes_ still run the real imphash/authentihash grammars,
+    which embed md5/sha256.)"""
+    seen: set[str] = set()
+    out: list[str] = []
+    for m in candidate_re.finditer(text):
+        value = m.group(0).lower()
+        if value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
 def parse_md5s(text):
     """."""
-    return _scan_candidates(text, _MD5_CANDIDATE_RE, ioc_grammars.md5)
+    return _scan_hash_candidates(text, _MD5_CANDIDATE_RE)
 
 
 def parse_sha1s(text):
     """."""
-    return _scan_candidates(text, _SHA1_CANDIDATE_RE, ioc_grammars.sha1)
+    return _scan_hash_candidates(text, _SHA1_CANDIDATE_RE)
 
 
 def parse_sha256s(text):
     """."""
-    return _scan_candidates(text, _SHA256_CANDIDATE_RE, ioc_grammars.sha256)
+    return _scan_hash_candidates(text, _SHA256_CANDIDATE_RE)
 
 
 def parse_sha512s(text):
     """."""
-    return _scan_candidates(text, _SHA512_CANDIDATE_RE, ioc_grammars.sha512)
+    return _scan_hash_candidates(text, _SHA512_CANDIDATE_RE)
 
 
 def parse_ssdeeps(text):
@@ -853,7 +907,24 @@ def parse_cves(text):
 
 def parse_ipv4_cidrs(text: str) -> list:
     """."""
-    return _scan_candidates(text, _IPV4_CIDR_CANDIDATE_RE, ioc_grammars.ipv4_cidr)
+    # Pure-Python fast path mirroring the ipv4_cidr grammar: the address half
+    # gets the same per-octet <256 check and leading-zero normalization as
+    # parse_ipv4_addresses (via _normalized_ipv4); the bit range is kept
+    # verbatim. The grammar's `Word(nums, max=2)` put no numeric bound on the
+    # bit range (so e.g. "/99" was accepted), and the candidate regex's
+    # `/\d{1,2}` reproduces that — deliberately unchanged here.
+    seen: set[str] = set()
+    out: list[str] = []
+    for m in _IPV4_CIDR_CANDIDATE_RE.finditer(text):
+        address, _, bits = m.group(0).partition("/")
+        normalized = _normalized_ipv4(address)
+        if normalized is None:
+            continue
+        value = f"{normalized}/{bits}"
+        if value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
 
 
 def _is_valid_ipv6_cidr(span: str) -> bool:

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -91,7 +91,13 @@ _IPV6_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9:])(?:[0-9A-Fa-f]*:){2,}[0-9A-Fa
 # lookarounds ARE Unicode-aware on purpose: they mirror the `\b` implied by
 # the grammar's `Word(nums, as_keyword=True)` octets, which rejected a quad
 # hugging a non-ASCII digit ("٣3.2.3.4", "1.2.3.4٣") because `\b` treats
-# the adjacent digit as a word character.
+# the adjacent digit as a word character. Deliberate divergence from the
+# old regex+grammar pipeline: its span-slicing was context-blind, so a quad
+# whose adjacent Unicode digit happened to be excluded from the candidate
+# span by regex backtracking was accepted ("1.2.3.4٣.5" -> "1.2.3.4") while
+# the same quad without the trailing ".5" was rejected. The lookarounds
+# reject every hugging-digit case uniformly; pinned in
+# test_unicode_digits_are_not_parsed_as_ipv4s.
 _IPV4_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9.])(?<!\d)(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?!\d)(?![A-Za-z0-9])(?!\.\S)")
 
 # Hash candidates: a hex run of exactly 32/40/64 chars. The leading lookbehind
@@ -99,10 +105,8 @@ _IPV4_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9.])(?<!\d)(?:[0-9]{1,3}\.){3}[0-
 # leading 'x'/'X' prefix is allowed (issue #41). The trailing lookahead mirrors
 # alphanum_word_end so a longer hex run isn't sliced into a shorter hash —
 # e.g. a 64-char run won't surface as an MD5 candidate.
-# NOTE: unlike the other candidate regexes these are *exact* mirrors of their
-# grammars, not supersets — parse_md5s/sha1s/sha256s/sha512s use them as the
-# sole validator via _scan_hash_candidates (no pyparsing pass). Keep them
-# byte-for-byte in sync with the md5/sha1/sha256/sha512 grammars.
+# NOTE: exact mirrors of their grammars, not supersets, and used as the sole
+# validators — see _scan_hash_candidates for the full contract.
 _MD5_CANDIDATE_RE = re.compile(r"(?<![A-WYZa-wyz0-9])[A-Fa-f0-9]{32}(?![A-Za-z0-9])")
 _SHA1_CANDIDATE_RE = re.compile(r"(?<![A-WYZa-wyz0-9])[A-Fa-f0-9]{40}(?![A-Za-z0-9])")
 _SHA256_CANDIDATE_RE = re.compile(r"(?<![A-WYZa-wyz0-9])[A-Fa-f0-9]{64}(?![A-Za-z0-9])")
@@ -603,10 +607,10 @@ def _scan_transformed(text, candidate_re, transform: Callable[[str], str | None]
 
 def parse_ipv4_addresses(text):
     """."""
-    # Pure-Python fast path (same asymmetry as parse_ipv6_addresses): the
-    # ipv4_address grammar's only transformation is the per-octet
-    # normalization reproduced by _normalized_ipv4, so skipping pyparsing
-    # preserves the output shape.
+    # Pure-Python fast path (see _scan_transformed): the ipv4_address
+    # grammar's only transformation is the per-octet normalization
+    # reproduced by _normalized_ipv4, so skipping pyparsing preserves the
+    # output shape.
     return _scan_transformed(text, _IPV4_CANDIDATE_RE, _normalized_ipv4)
 
 
@@ -784,10 +788,10 @@ def _is_valid_ipv6(s: str) -> bool:
 
 def parse_ipv6_addresses(text):
     """."""
-    # Asymmetry with the other parse_* helpers: this validates candidates
-    # in pure Python via _is_valid_ipv6 instead of routing them through
-    # _scan_candidates + a pyparsing grammar. The grammar applies no parse
-    # actions to ipv6_address, so skipping it preserves the output shape.
+    # Pure-Python fast path (see _scan_transformed): candidates are
+    # validated via _is_valid_ipv6 instead of _scan_candidates + a pyparsing
+    # grammar. The grammar applies no parse actions to ipv6_address, so
+    # skipping it preserves the output shape.
     return _scan_validated(text, _IPV6_CANDIDATE_RE, _is_valid_ipv6)
 
 

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -91,13 +91,15 @@ _IPV6_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9:])(?:[0-9A-Fa-f]*:){2,}[0-9A-Fa
 # lookarounds ARE Unicode-aware on purpose: they mirror the `\b` implied by
 # the grammar's `Word(nums, as_keyword=True)` octets, which rejected a quad
 # hugging a non-ASCII digit ("٣3.2.3.4", "1.2.3.4٣") because `\b` treats
-# the adjacent digit as a word character. Deliberate divergence from the
-# old regex+grammar pipeline: its span-slicing was context-blind, so a quad
-# whose adjacent Unicode digit happened to be excluded from the candidate
-# span by regex backtracking was accepted ("1.2.3.4٣.5" -> "1.2.3.4") while
-# the same quad without the trailing ".5" was rejected. The lookarounds
-# reject every hugging-digit case uniformly; pinned in
-# test_unicode_digits_are_not_parsed_as_ipv4s.
+# the adjacent digit as a word character. Enforcing that here fixes a leak
+# in the old regex+grammar pipeline rather than diverging from it: because
+# _scan_candidates runs the grammar on an *isolated* span, a hugging digit
+# that regex backtracking pushed outside the span was invisible to the
+# grammar's `\b`, so the same quad was accepted or rejected depending on
+# surrounding text ("١010.0.0.1" -> "10.0.0.1" and "1.2.3.4٣.5" ->
+# "1.2.3.4" were accepted; bare "٣3.2.3.4" / "1.2.3.4٣" were rejected).
+# The lookarounds apply the grammar's own boundary rule to every
+# hugging-digit case; pinned in test_unicode_digits_are_not_parsed_as_ipv4s.
 _IPV4_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9.])(?<!\d)(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?!\d)(?![A-Za-z0-9])(?!\.\S)")
 
 # Hash candidates: a hex run of exactly 32/40/64 chars. The leading lookbehind

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -585,22 +585,29 @@ def _normalized_ipv4(span: str) -> str | None:
     return ".".join(map(str, octets))
 
 
+def _scan_transformed(text, candidate_re, transform: Callable[[str], str | None]) -> list[str]:
+    """Run `transform` on each span matched by `candidate_re`, keeping the
+    first-seen order of the non-None results and deduplicating on the
+    *transformed* value (so e.g. "1.2.3.4" and "01.2.3.4" are one result).
+    This is the shared shape of every pure-Python fast path that bypasses
+    pyparsing; `transform` returns the parsed value or None to reject."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for m in candidate_re.finditer(text):
+        value = transform(m.group(0))
+        if value is not None and value not in seen:
+            seen.add(value)
+            out.append(value)
+    return out
+
+
 def parse_ipv4_addresses(text):
     """."""
     # Pure-Python fast path (same asymmetry as parse_ipv6_addresses): the
     # ipv4_address grammar's only transformation is the per-octet
     # normalization reproduced by _normalized_ipv4, so skipping pyparsing
-    # preserves the output shape. Note dedup happens on the *normalized*
-    # value, matching the old grammar path ("1.2.3.4" and "01.2.3.4" are
-    # one result).
-    seen: set[str] = set()
-    out: list[str] = []
-    for m in _IPV4_CANDIDATE_RE.finditer(text):
-        value = _normalized_ipv4(m.group(0))
-        if value is not None and value not in seen:
-            seen.add(value)
-            out.append(value)
-    return out
+    # preserves the output shape.
+    return _scan_transformed(text, _IPV4_CANDIDATE_RE, _normalized_ipv4)
 
 
 def _scan_candidates(text, candidate_re, grammar):
@@ -823,16 +830,7 @@ def _scan_validated(text, candidate_re, validator):
     """Like _scan_candidates, but uses a pure-Python validator on the matched
     span instead of running a pyparsing grammar. Used where the grammar adds
     no transformation and a hand-written check is faster."""
-    seen: set[str] = set()
-    out: list[str] = []
-    for m in candidate_re.finditer(text):
-        span = m.group(0)
-        if span in seen:
-            continue
-        if validator(span):
-            seen.add(span)
-            out.append(span)
-    return out
+    return _scan_transformed(text, candidate_re, lambda span: span if validator(span) else None)
 
 
 def parse_complete_email_addresses(text: str, *, parse_unicode_iocs: bool = False) -> list:
@@ -873,15 +871,9 @@ def _scan_hash_candidates(text, candidate_re):
     ioc_grammars ever grows a rule its candidate regex doesn't mirror, these
     parsers must go back through _scan_candidates. (parse_imphashes_ /
     parse_authentihashes_ still run the real imphash/authentihash grammars,
-    which embed md5/sha256.)"""
-    seen: set[str] = set()
-    out: list[str] = []
-    for m in candidate_re.finditer(text):
-        value = m.group(0).lower()
-        if value not in seen:
-            seen.add(value)
-            out.append(value)
-    return out
+    which embed md5/sha256.) The regex/grammar equivalence is asserted by
+    tests/test_fast_path_equivalence.py."""
+    return _scan_transformed(text, candidate_re, str.lower)
 
 
 def parse_md5s(text):
@@ -919,26 +911,23 @@ def parse_cves(text):
     return _scan_candidates(text, _CVE_CANDIDATE_RE, ioc_grammars.cve)
 
 
+def _normalized_ipv4_cidr(span: str) -> str | None:
+    """Transform for the ipv4_cidr fast path: the address half gets the same
+    per-octet <256 check and leading-zero normalization as
+    parse_ipv4_addresses (via _normalized_ipv4); the bit range is kept
+    verbatim. The grammar's `Word(nums, max=2)` put no numeric bound on the
+    bit range (so e.g. "/99" was accepted), and the candidate regex's
+    `/[0-9]{1,2}` reproduces that — deliberately unchanged here."""
+    address, _, bits = span.partition("/")
+    normalized = _normalized_ipv4(address)
+    if normalized is None:
+        return None
+    return f"{normalized}/{bits}"
+
+
 def parse_ipv4_cidrs(text: str) -> list:
     """."""
-    # Pure-Python fast path mirroring the ipv4_cidr grammar: the address half
-    # gets the same per-octet <256 check and leading-zero normalization as
-    # parse_ipv4_addresses (via _normalized_ipv4); the bit range is kept
-    # verbatim. The grammar's `Word(nums, max=2)` put no numeric bound on the
-    # bit range (so e.g. "/99" was accepted), and the candidate regex's
-    # `/\d{1,2}` reproduces that — deliberately unchanged here.
-    seen: set[str] = set()
-    out: list[str] = []
-    for m in _IPV4_CIDR_CANDIDATE_RE.finditer(text):
-        address, _, bits = m.group(0).partition("/")
-        normalized = _normalized_ipv4(address)
-        if normalized is None:
-            continue
-        value = f"{normalized}/{bits}"
-        if value not in seen:
-            seen.add(value)
-            out.append(value)
-    return out
+    return _scan_transformed(text, _IPV4_CIDR_CANDIDATE_RE, _normalized_ipv4_cidr)
 
 
 def _is_valid_ipv6_cidr(span: str) -> bool:

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -84,8 +84,15 @@ _IPV6_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9:])(?:[0-9A-Fa-f]*:){2,}[0-9A-Fa
 # fifth dotted segment ("1.2.3.4.5") is excluded. The per-octet `<256` check
 # and the grammar's leading-zero normalization are applied by
 # `_normalized_ipv4` (pure Python — see parse_ipv4_addresses), which rejects
-# e.g. "999.1.1.1".
-_IPV4_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9.])(?:\d{1,3}\.){3}\d{1,3}(?![A-Za-z0-9])(?!\.\S)")
+# e.g. "999.1.1.1". Octets are `[0-9]`, not `\d`: with the ipv4_address
+# grammar (whose Word(nums) is ASCII-only) no longer run on these spans,
+# a Unicode-aware `\d` would let int() fabricate addresses from non-ASCII
+# digit runs like "١.٢.٣.٤" / "１.２.３.４". The `(?<!\d)` / `(?!\d)`
+# lookarounds ARE Unicode-aware on purpose: they mirror the `\b` implied by
+# the grammar's `Word(nums, as_keyword=True)` octets, which rejected a quad
+# hugging a non-ASCII digit ("٣3.2.3.4", "1.2.3.4٣") because `\b` treats
+# the adjacent digit as a word character.
+_IPV4_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9.])(?<!\d)(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?!\d)(?![A-Za-z0-9])(?!\.\S)")
 
 # Hash candidates: a hex run of exactly 32/40/64 chars. The leading lookbehind
 # mirrors file_hash_word_start (word_chars = alphanums minus 'x'/'X'), so a
@@ -248,7 +255,15 @@ _BITCOIN_CANDIDATE_RE = re.compile(
 # match the ipv4 prefilter (alphanum_word_start excluding leading '.' too)
 # and alphanum_word_end. Per-octet `<256` and the bit-range bounds are
 # still enforced by the grammar.
-_IPV4_CIDR_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9.])(?:\d{1,3}\.){3}\d{1,3}/\d{1,2}(?![A-Za-z0-9])")
+# `[0-9]`, not `\d`, for the same reason as _IPV4_CANDIDATE_RE: the grammar's
+# ASCII-only Word(nums) no longer backstops these spans, and the bit range is
+# emitted verbatim — a Unicode-aware `\d` would let non-ASCII digits through.
+# The Unicode-aware `(?<!\d)` matches _IPV4_CANDIDATE_RE (see the comment
+# there); no trailing `(?!\d)` on the bit range because the grammar's
+# `Word(nums, max=2)` was not a keyword — it truncated before a non-ASCII
+# digit ("1.2.3.4/1٣" -> "1.2.3.4/1") rather than rejecting, and the
+# `(?![A-Za-z0-9])` lookahead reproduces exactly that.
+_IPV4_CIDR_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9.])(?<!\d)(?:[0-9]{1,3}\.){3}[0-9]{1,3}/[0-9]{1,2}(?![A-Za-z0-9])")
 
 # IPv6 CIDR candidates: hex+colon runs that contain at least two colons,
 # followed by '/' and 1-3 digit bit-range. Same boundary shape as the IPv6
@@ -564,11 +579,10 @@ def _normalized_ipv4(span: str) -> str | None:
     `str(int(...))` parse action ("001.002.003.004" -> "1.2.3.4"). The
     candidate regexes guarantee four 1-3 digit groups and enforce the word
     boundaries, so neither is re-checked here."""
-    octets = span.split(".")
-    for octet in octets:
-        if int(octet) > 255:
-            return None
-    return ".".join(str(int(octet)) for octet in octets)
+    octets = [int(octet) for octet in span.split(".")]
+    if any(octet > 255 for octet in octets):
+        return None
+    return ".".join(map(str, octets))
 
 
 def parse_ipv4_addresses(text):

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -639,6 +639,13 @@ def test_unicode_digits_are_not_parsed_as_ipv4s():
     # (a non-ASCII digit is a word character to `\b`).
     assert find_iocs("٣3.2.3.4")["ipv4s"] == []
     assert find_iocs("1.2.3.4٣")["ipv4s"] == []
+    # Deliberate divergence from the old regex+grammar pipeline, whose
+    # context-blind span-slicing accepted these two ("1.2.3.4" /
+    # "1.2.3.4/8") because regex backtracking happened to exclude the
+    # hugging Unicode digit from the candidate span. The lookarounds reject
+    # every hugging-digit case uniformly (see _IPV4_CANDIDATE_RE).
+    assert find_iocs("1.2.3.4٣.5")["ipv4s"] == []
+    assert find_iocs(".٣1.2.3.4/8")["ipv4_cidrs"] == []
 
     # CIDRs: a Unicode digit in the bit range terminates the match exactly as
     # the ASCII-only grammar did (the '1.2.3.4/1' prefix is still the IOC).

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -623,3 +623,24 @@ def test_certificate_serial_number_issue_96():
     print(observables)
     assert observables["ipv6s"] == []
     assert observables["mac_addresses"] == []
+
+
+def test_unicode_digits_are_not_parsed_as_ipv4s():
+    """The pure-Python IPv4 fast path must not accept non-ASCII digits. A
+    Unicode-aware `\\d` in the candidate regexes plus int()'s Unicode-digit
+    support would fabricate addresses (e.g. '١.٢.٣.٤' -> '1.2.3.4') that the
+    ASCII-only ipv4_address grammar never matched; the candidate regexes use
+    `[0-9]` to keep the old behavior."""
+    # Arabic-Indic and fullwidth digit quads: no IPv4s.
+    assert find_iocs("١.٢.٣.٤")["ipv4s"] == []
+    assert find_iocs("１.２.３.４")["ipv4s"] == []
+    # A Unicode digit hugging an ASCII quad rejects the whole match, mirroring
+    # the `\b` implied by the grammar's `Word(nums, as_keyword=True)` octets
+    # (a non-ASCII digit is a word character to `\b`).
+    assert find_iocs("٣3.2.3.4")["ipv4s"] == []
+    assert find_iocs("1.2.3.4٣")["ipv4s"] == []
+
+    # CIDRs: a Unicode digit in the bit range terminates the match exactly as
+    # the ASCII-only grammar did (the '1.2.3.4/1' prefix is still the IOC).
+    assert find_iocs("net 1.2.3.4/1٣")["ipv4_cidrs"] == ["1.2.3.4/1"]
+    assert find_iocs("١.٢.٣.٤/٨")["ipv4_cidrs"] == []

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -639,11 +639,12 @@ def test_unicode_digits_are_not_parsed_as_ipv4s():
     # (a non-ASCII digit is a word character to `\b`).
     assert find_iocs("٣3.2.3.4")["ipv4s"] == []
     assert find_iocs("1.2.3.4٣")["ipv4s"] == []
-    # Deliberate divergence from the old regex+grammar pipeline, whose
-    # context-blind span-slicing accepted these two ("1.2.3.4" /
-    # "1.2.3.4/8") because regex backtracking happened to exclude the
-    # hugging Unicode digit from the candidate span. The lookarounds reject
-    # every hugging-digit case uniformly (see _IPV4_CANDIDATE_RE).
+    # The old regex+grammar pipeline accepted these two ("1.2.3.4" /
+    # "1.2.3.4/8") because it ran the grammar on an isolated span and regex
+    # backtracking had already pushed the hugging Unicode digit outside it,
+    # hiding it from the grammar's `\b` — the same quad was rejected in the
+    # cases just above. The lookarounds apply that boundary rule to every
+    # hugging-digit case (see _IPV4_CANDIDATE_RE).
     assert find_iocs("1.2.3.4٣.5")["ipv4s"] == []
     assert find_iocs(".٣1.2.3.4/8")["ipv4_cidrs"] == []
 

--- a/tests/test_fast_path_equivalence.py
+++ b/tests/test_fast_path_equivalence.py
@@ -1,0 +1,100 @@
+"""Assert the pure-Python fast paths are equivalent to running the pyparsing
+grammars over the same candidate spans.
+
+parse_md5s/sha1s/sha256s/sha512s and parse_ipv4_addresses/parse_ipv4_cidrs no
+longer run their grammars — the candidate regex (plus a small Python
+transform) is the sole validator. The grammars still exist (md5/sha256 are
+embedded in the imphash/authentihash grammars, ipv4_address in the URL/email
+grammars), so a grammar edit that skips the regexes would silently make the
+two disagree. These tests make the "keep them in sync" comments executable:
+each compares a fast-path parser against `_scan_candidates` with the same
+candidate regex and the corresponding grammar."""
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from ioc_finder import ioc_grammars
+from ioc_finder.ioc_finder import (
+    _IPV4_CANDIDATE_RE,
+    _IPV4_CIDR_CANDIDATE_RE,
+    _MD5_CANDIDATE_RE,
+    _SHA1_CANDIDATE_RE,
+    _SHA256_CANDIDATE_RE,
+    _SHA512_CANDIDATE_RE,
+    _scan_candidates,
+    parse_ipv4_addresses,
+    parse_ipv4_cidrs,
+    parse_md5s,
+    parse_sha1s,
+    parse_sha256s,
+    parse_sha512s,
+)
+
+HASH_CASES = [
+    pytest.param(parse_md5s, _MD5_CANDIDATE_RE, ioc_grammars.md5, 32, id="md5"),
+    pytest.param(parse_sha1s, _SHA1_CANDIDATE_RE, ioc_grammars.sha1, 40, id="sha1"),
+    pytest.param(parse_sha256s, _SHA256_CANDIDATE_RE, ioc_grammars.sha256, 64, id="sha256"),
+    pytest.param(parse_sha512s, _SHA512_CANDIDATE_RE, ioc_grammars.sha512, 128, id="sha512"),
+]
+
+# Characters chosen to probe the boundary rules: hex in both cases, the
+# 'x'/'X' prefix carve-out (issue #41), non-hex alphanumerics, separators,
+# and non-ASCII digits (which `\b`-style boundaries treat as word chars).
+BOUNDARY_ALPHABET = "0123456789abcdefABCDEFxXgG._-:/ \n٣١２१"
+
+
+@pytest.mark.parametrize("parser, candidate_re, grammar, length", HASH_CASES)
+def test_hash_fast_path_matches_grammar_on_boundary_cases(parser, candidate_re, grammar, length):
+    h = "aB3" * length  # long mixed-case hex pool to slice from
+    cases = [
+        h[:length],
+        f"x{h[:length]}",
+        f"X{h[:length]}",
+        f"g{h[:length]}",  # non-x letter prefix: rejected by both
+        f"{h[:length]}g",
+        h[: length - 1],  # one short: no match
+        h[: length + 1],  # one long: no match
+        f"a {h[:length]} b {h[:length].upper()}",  # dedup on downcased value
+        f"٣{h[:length]}",  # non-ASCII digit hugging the run
+        f"{h[:length]}٣",
+        f"-{h[:length]}-",
+        f"{h[:length]}.{h[:length]}",
+    ]
+    for text in cases:
+        assert parser(text) == _scan_candidates(text, candidate_re, grammar), text
+
+
+@pytest.mark.parametrize("parser, candidate_re, grammar, length", HASH_CASES)
+@settings(deadline=None)
+@given(st.text(alphabet=BOUNDARY_ALPHABET, max_size=200))
+def test_hash_fast_path_matches_grammar(parser, candidate_re, grammar, length, text):
+    assert parser(text) == _scan_candidates(text, candidate_re, grammar)
+
+
+IPV4_EXAMPLES = [
+    "1.2.3.4",
+    "001.002.003.004",
+    "999.1.1.1",
+    "1.2.3.4.5",
+    "٣3.2.3.4",
+    "1.2.3.4٣",
+    "1.2.3.4/24 010.0.0.0/8 1.2.3.4/99 1.2.3.4/246",
+    "net 1.2.3.4/1٣",
+]
+
+
+def _assert_ipv4_equivalence(text):
+    assert parse_ipv4_addresses(text) == _scan_candidates(text, _IPV4_CANDIDATE_RE, ioc_grammars.ipv4_address), text
+    assert parse_ipv4_cidrs(text) == _scan_candidates(text, _IPV4_CIDR_CANDIDATE_RE, ioc_grammars.ipv4_cidr), text
+
+
+@pytest.mark.parametrize("text", IPV4_EXAMPLES)
+def test_ipv4_fast_path_matches_grammar_on_boundary_cases(text):
+    _assert_ipv4_equivalence(text)
+
+
+@settings(deadline=None)
+@given(st.text(alphabet=BOUNDARY_ALPHABET, max_size=200))
+def test_ipv4_fast_path_matches_grammar(text):
+    _assert_ipv4_equivalence(text)

--- a/tests/test_fast_path_equivalence.py
+++ b/tests/test_fast_path_equivalence.py
@@ -8,7 +8,17 @@ embedded in the imphash/authentihash grammars, ipv4_address in the URL/email
 grammars), so a grammar edit that skips the regexes would silently make the
 two disagree. These tests make the "keep them in sync" comments executable:
 each compares a fast-path parser against `_scan_candidates` with the same
-candidate regex and the corresponding grammar."""
+candidate regex and the corresponding grammar.
+
+Oracle scope: `_scan_candidates` runs the grammar on the *isolated* candidate
+span, so these tests check transform-vs-grammar agreement on matched spans —
+they cannot see context-sensitive boundary effects (a too-strict candidate
+regex makes both sides return [] and pass). Those boundary semantics are
+pinned separately by explicit cases in test_edge_cases.py
+(test_unicode_digits_are_not_parsed_as_ipv4s). A full-text grammar scan is
+not a usable oracle here: the grammar's `as_keyword` \\b treats '_' and
+non-ASCII letters as word chars, so it diverges from the candidate-regex
+pipeline (old and new alike) on inputs like '_1.2.3.4'."""
 
 import pytest
 from hypothesis import given, settings
@@ -65,10 +75,10 @@ def test_hash_fast_path_matches_grammar_on_boundary_cases(parser, candidate_re, 
         assert parser(text) == _scan_candidates(text, candidate_re, grammar), text
 
 
-@pytest.mark.parametrize("parser, candidate_re, grammar, length", HASH_CASES)
+@pytest.mark.parametrize("parser, candidate_re, grammar, _length", HASH_CASES)
 @settings(deadline=None)
 @given(st.text(alphabet=BOUNDARY_ALPHABET, max_size=200))
-def test_hash_fast_path_matches_grammar(parser, candidate_re, grammar, length, text):
+def test_hash_fast_path_matches_grammar(parser, candidate_re, grammar, _length, text):
     assert parser(text) == _scan_candidates(text, candidate_re, grammar)
 
 


### PR DESCRIPTION
## Changes

- Add `_normalized_ipv4` pure-Python validator (per-octet <256 check + leading-zero normalization, identical to the `ipv4_address` grammar's parse actions) and use it in `parse_ipv4_addresses` and `parse_ipv4_cidrs` instead of running the pyparsing grammar on each candidate span
- Add a pure-Python fast path for `parse_md5s`/`parse_sha1s`/`parse_sha256s`/`parse_sha512s` — the hash candidate regexes are exact mirrors of their grammars and the grammars' only parse action is downcasing, so the lowercased regex match is returned directly
- Keep the IPv4/CIDR candidate regexes ASCII-only (`[0-9]`, not `\d`) with Unicode-aware `(?<!\d)`/`(?!\d)` lookarounds mirroring the grammar's `as_keyword` `\b`, so the removed grammar backstop cannot let `int()` fabricate addresses from non-ASCII digit runs (`'١.٢.٣.٤'`)
- Fix a boundary leak in the old pipeline on inputs with non-ASCII digits: because `_scan_candidates` ran the grammar on an *isolated* candidate span, a hugging Unicode digit that regex backtracking had already pushed outside the span was invisible to the grammar's `\b`, so the same quad was accepted or rejected depending on surrounding text (`'١010.0.0.1'` → `'10.0.0.1'` and `'1.2.3.4٣.5'` → `'1.2.3.4'` were accepted, while bare `'٣3.2.3.4'`/`'1.2.3.4٣'` were rejected). The lookarounds apply the grammar's own boundary rule to every hugging-digit case, so this converges on the grammar rather than diverging from it (pinned in `test_edge_cases.py`)
- Consolidate the fast-path scan loops into `_scan_transformed` and reimplement `_scan_validated` on top of it
- Add `tests/test_fast_path_equivalence.py`: boundary cases + hypothesis property tests asserting each fast path matches `_scan_candidates` with the same candidate regex and the still-live grammar (md5/sha256 remain embedded in imphash/authentihash)
- `find_iocs` benchmark profile: 4.65s → ~2.67s (`parse_ipv4_addresses` 1.15s → 0.09s)
