### PR TITLE
Fix scheme-less URL prefilter gaps, CVE year grammar, and registry double-space check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+
+- Scheme-less URLs with an explicit port (`example.com:8080/admin`) or an IPv4 host (`1.2.3.4/gate.php`) are now found. The `scheme_less_url` grammar already accepted both, but the `_URL_MARKER_RE` candidate prefilter only recognized `://` and `.tld/` markers, so these spans were never handed to the grammar ([#406](https://github.com/fhightower/ioc-finder/pull/406)).
+- Fixed CVE identifiers whose year digits are all 1s and 2s (e.g. `CVE-2121-12345`). The `year` grammar was `Word("12") + Word(nums, exact=3)`; `Word` is greedy and does not backtrack, so it consumed every leading 1/2 digit and left too few for the 3-digit remainder. It is now a single `Regex(r"[12][0-9]{3}")` — spelled `[0-9]` rather than `\d` because `re` is Unicode-aware where `Word(nums)` was ASCII-only, and this grammar is the validator behind a deliberately broad candidate regex.
+- Registry-key path sections containing an internal run of multiple spaces no longer absorb surrounding prose into the parsed path. The double-space check used start-anchored `re.match`, so it only ever saw a run of spaces at the very start of a section.
+- Rejected non-ASCII digits in the socket-address and IPv6 CIDR candidate regexes (`[0-9]` instead of `\d`). Those parsers validate in pure Python with `str.isdigit()`/`int()`, which accept Unicode digits, so inputs like `١.٢.٣.٤:80` or `2001:db8::/٣٢` were emitted verbatim as IOCs.
+
+### Changed
+
+- The IPv4 URL marker excludes the bare-CIDR shape (a quad plus `/` plus one or two digits ending the token), so netblock feeds and firewall dumps don't pay for a candidate span per CIDR — each costs ~750µs of grammar work that `find_iocs` then discards in its CIDR removal pass. 2000 CIDRs through `parse_urls` went from 2.0s to 0.002s. The exclusion is narrow: anything past the prefix-length digits (`/8.php`, `/12?a=b`, `/80/x`) still marks.
+- The IPv4 URL marker matches only the last two octets (`.3.4/`) so that it starts with a literal `.`, like the `.tld/` alternative beside it. `re` prefilters an alternation branch by the set of characters that can start it, and leading with `[0-9]` widened that set enough to defeat the skip — the full-quad form scanned the benchmark corpus in 1.21ms against 0.15ms for the original two alternatives, for an identical set of hits. No coverage is lost, since every quad plus `/` contains `.<octet>.<octet>/` and the marker only locates a span that is then expanded to its whitespace boundaries.
+
 ## [9.4.1] - 2026.06.17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 
 - The IPv4 URL marker excludes the bare-CIDR shape (a quad plus `/` plus one or two digits ending the token), so netblock feeds and firewall dumps don't pay for a candidate span per CIDR — each costs ~750µs of grammar work that `find_iocs` then discards in its CIDR removal pass. 2000 CIDRs through `parse_urls` went from 2.0s to 0.002s. The exclusion is narrow: anything past the prefix-length digits (`/8.php`, `/12?a=b`, `/80/x`) still marks.
+- The URL marker's port runs are unbounded rather than capped at five digits, keeping the marker a superset of the `port = Word(":", nums, min=2)` grammar it gates. A cap left `example.com:123456/x` unreachable while the scheme-ful `http://example.com:123456/x` still parsed, since the `://` marker never looks at the port.
 - The IPv4 URL marker matches only the last two octets (`.3.4/`) so that it starts with a literal `.`, like the `.tld/` alternative beside it. `re` prefilters an alternation branch by the set of characters that can start it, and leading with `[0-9]` widened that set enough to defeat the skip — the full-quad form scanned the benchmark corpus in 1.21ms against 0.15ms for the original two alternatives, for an identical set of hits. No coverage is lost, since every quad plus `/` contains `.<octet>.<octet>/` and the marker only locates a span that is then expanded to its whitespace boundaries.
 
 ## [9.4.1] - 2026.06.17

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -114,11 +114,12 @@ _SHA1_CANDIDATE_RE = re.compile(r"(?<![A-WYZa-wyz0-9])[A-Fa-f0-9]{40}(?![A-Za-z0
 _SHA256_CANDIDATE_RE = re.compile(r"(?<![A-WYZa-wyz0-9])[A-Fa-f0-9]{64}(?![A-Za-z0-9])")
 
 # CVE candidates: "CVE" + dash/space separators + 4-digit year (1xxx/2xxx) + dashes
-# + 4-or-more digit id. Mirrors `year = Word("12") + Word(nums, exact=3)` and the
-# trailing `Word(nums, min=4)` + alphanum_word_end. Case-insensitive to match
-# CaselessLiteral("cve").
+# + 4-or-more digit id. Mirrors `year = Regex(r"[12][0-9]{3}")` and the trailing
+# `Word(nums, min=4)` + alphanum_word_end. Case-insensitive to match
+# CaselessLiteral("cve"). Digits are `[0-9]`, not `\d`, to match the ASCII-only
+# grammar rather than relying on it to reject non-ASCII digit runs.
 _CVE_CANDIDATE_RE = re.compile(
-    r"(?<![A-Za-z0-9])cve[- ]+[12]\d{3}-+\d{4,}(?![A-Za-z0-9])",
+    r"(?<![A-Za-z0-9])cve[- ]+[12][0-9]{3}-+[0-9]{4,}(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
 
@@ -141,11 +142,28 @@ _AUTHENTIHASH_CANDIDATE_RE = re.compile(r"authentihash[^a-z0-9]*[a-f0-9]{64}(?![
 # offset; every alternative here is anchored (no leading unbounded
 # quantifier), so the scan stays linear. The markers are locators only — the
 # URL grammars remain the validators (e.g. `999.1.2.3/x` produces a candidate
-# span the grammar then rejects).
+# span the grammar then rejects). Digits are `[0-9]`, not `\d`, purely for
+# consistency with the other candidate regexes here; the grammar would reject
+# non-ASCII digits either way.
+#
+# The IPv4 alternative excludes the bare-CIDR shape (quad + '/' + one or two
+# digits ending the whitespace-delimited token). Without that exclusion every
+# `10.0.0.0/8` in a netblock feed or firewall dump becomes a candidate span,
+# and the ~750µs of grammar work it costs is pure waste: `find_iocs` strips
+# the resulting "URL" again in the issue-#91 removal pass, and standalone
+# `parse_urls("10.0.0.0/8")` returned nothing before the IPv4 marker existed.
+# The exclusion is deliberately narrow — anything after the digits (`/8.php`,
+# `/12?a=b`, `/80/x`) still marks — so a CIDR trailed by prose punctuation
+# ("10.0.0.0/8.") does still pay for a candidate span. Bulk CIDR text, the
+# case that actually matters for throughput, is whitespace-delimited.
+#
+# Not covered: bracketed IPv6 hosts (`[2001:db8::1]:8080/gate.php`). Adding a
+# marker for them would not help — the url grammars reject the scheme-*ful*
+# form too, so that is a grammar gap rather than a marker gap.
 _URL_MARKER_RE = re.compile(
     r"://"
-    r"|\.[A-Za-z][A-Za-z0-9-]*(?::\d{1,5})?/"
-    r"|(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?/"
+    r"|\.[A-Za-z][A-Za-z0-9-]*(?::[0-9]{1,5})?/"
+    r"|(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?::[0-9]{1,5})?/(?![0-9]{1,2}(?!\S))"
 )
 
 # MAC candidates: the three notations the grammar accepts —

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -172,10 +172,19 @@ _AUTHENTIHASH_CANDIDATE_RE = re.compile(r"authentihash[^a-z0-9]*[a-f0-9]{64}(?![
 # Not covered: bracketed IPv6 hosts (`[2001:db8::1]:8080/gate.php`). Adding a
 # marker for them would not help — the url grammars reject the scheme-*ful*
 # form too, so that is a grammar gap rather than a marker gap.
+# The port runs are unbounded (`[0-9]+`), not capped at the five digits a real
+# TCP port needs, because the grammar's `port = Word(":", nums, min=2)` is
+# itself unbounded and a marker must stay a superset of what its grammar
+# accepts. A five-digit cap made `example.com:123456/x` unreachable while the
+# scheme-*ful* `http://example.com:123456/x` still parsed (the `://` marker
+# does not look at the port), i.e. the same authority parsed or not depending
+# on whether a scheme was present. Unbounded costs nothing measurable — the
+# runs sit behind a literal '.' so they are rarely entered, and they stay
+# linear on adversarial digit runs.
 _URL_MARKER_RE = re.compile(
     r"://"
-    r"|\.[A-Za-z][A-Za-z0-9-]*(?::[0-9]{1,5})?/"
-    r"|\.[0-9]{1,3}\.[0-9]{1,3}(?::[0-9]{1,5})?/(?![0-9]{1,2}(?!\S))"
+    r"|\.[A-Za-z][A-Za-z0-9-]*(?::[0-9]+)?/"
+    r"|\.[0-9]{1,3}\.[0-9]{1,3}(?::[0-9]+)?/(?![0-9]{1,2}(?!\S))"
 )
 
 # MAC candidates: the three notations the grammar accepts —

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -132,9 +132,9 @@ _IMPHASH_CANDIDATE_RE = re.compile(r"(?:imphash|import hash)[^a-z0-9]*[a-f0-9]{3
 _AUTHENTIHASH_CANDIDATE_RE = re.compile(r"authentihash[^a-z0-9]*[a-f0-9]{64}(?![a-z0-9])")
 
 # URL marker: '://' (scheme present), '.<tld>[:port]/' (scheme-less URL with
-# a path), or an IPv4-shaped host + optional port + '/' (the scheme_less_url
-# grammar's url_authority accepts ipv4_address hosts, and the letter-after-dot
-# marker can never fire on one). The candidate span is built in Python by
+# a path), or the tail of an IPv4-shaped host + optional port + '/' (the
+# scheme_less_url grammar's url_authority accepts ipv4_address hosts, and the
+# letter-after-dot marker can never fire on one). The candidate span is built in Python by
 # expanding from each marker out to whitespace boundaries (see
 # `_url_candidate_spans`). A pure regex of the form `\S*<marker>\S*` would go
 # quadratic on long non-whitespace, non-URL runs (e.g. 10k bytes of base64)
@@ -157,13 +157,25 @@ _AUTHENTIHASH_CANDIDATE_RE = re.compile(r"authentihash[^a-z0-9]*[a-f0-9]{64}(?![
 # ("10.0.0.0/8.") does still pay for a candidate span. Bulk CIDR text, the
 # case that actually matters for throughput, is whitespace-delimited.
 #
+# The IPv4 alternative matches only the last two octets (`.3.4/`), not the
+# whole quad, so that it starts with a literal '.' like the alternative above
+# it. This matters a lot: `re` prefilters a branch by the set of characters
+# that can start it, and leading the alternation with `[0-9]` widens that set
+# enough to defeat the skip — the full-quad form scanned the benchmark corpus
+# in 1.21ms against 0.15ms for the two original alternatives, an 8x cost for
+# an identical set of hits. Matching the tail costs nothing in coverage: every
+# quad + '/' contains `.<octet>.<octet>/`, and markers only locate the span
+# (`_url_candidate_spans` expands back to the whitespace boundaries), so the
+# leading octets are recovered anyway. It does let a non-quad like `v1.2.3/x`
+# mark, which is fine — that is what "locators only" buys.
+#
 # Not covered: bracketed IPv6 hosts (`[2001:db8::1]:8080/gate.php`). Adding a
 # marker for them would not help — the url grammars reject the scheme-*ful*
 # form too, so that is a grammar gap rather than a marker gap.
 _URL_MARKER_RE = re.compile(
     r"://"
     r"|\.[A-Za-z][A-Za-z0-9-]*(?::[0-9]{1,5})?/"
-    r"|(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?::[0-9]{1,5})?/(?![0-9]{1,2}(?!\S))"
+    r"|\.[0-9]{1,3}\.[0-9]{1,3}(?::[0-9]{1,5})?/(?![0-9]{1,2}(?!\S))"
 )
 
 # MAC candidates: the three notations the grammar accepts —

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -294,7 +294,11 @@ _IPV4_CIDR_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9.])(?<!\d)(?:[0-9]{1,3}\.){
 # refanging those forms would require running the validator against the
 # post-fang text, which has its own quirks; this narrow boundary fix is
 # enough to keep the partial-host truncation from surfacing.
-_IPV6_CIDR_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9:\])])(?:[0-9A-Fa-f]*:){2,}[0-9A-Fa-f]*/\d{1,3}(?![A-Za-z0-9])")
+#
+# The bit range is `[0-9]`, not `\d`: this parser is pure-Python (no grammar
+# backstop) and `str.isdigit()` in the validator accepts non-ASCII digits, so
+# a Unicode-aware `\d` would emit CIDRs like "2001:db8::/٣٢" verbatim.
+_IPV6_CIDR_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9:\])])(?:[0-9A-Fa-f]*:){2,}[0-9A-Fa-f]*/[0-9]{1,3}(?![A-Za-z0-9])")
 
 # Socket address candidates: either a dotted IPv4 quad or a bracketed IPv6
 # literal, followed by ':' and a 1..5 digit port. Boundaries reject hugging
@@ -302,10 +306,15 @@ _IPV6_CIDR_CANDIDATE_RE = re.compile(r"(?<![A-Za-z0-9:\])])(?:[0-9A-Fa-f]*:){2,}
 # numeric port range, octet ranges, and IPv6 shape are validated by the
 # Python validator below; the prefilter is intentionally a superset.
 # See https://github.com/fhightower/ioc-finder/issues/248.
+#
+# Digits are `[0-9]`, not `\d`: this parser is pure-Python (no grammar
+# backstop) and the validator's `str.isdigit()`/`int()` accept non-ASCII
+# digits, so a Unicode-aware `\d` would emit sockets like "١.٢.٣.٤:80" or
+# "1.2.3.4:٨0" verbatim.
 _SOCKET_ADDRESS_CANDIDATE_RE = re.compile(
     r"(?<![A-Za-z0-9.])"
-    r"(?:(?:\d{1,3}\.){3}\d{1,3}|\[[0-9A-Fa-f:]+\])"
-    r":\d{1,5}"
+    r"(?:(?:[0-9]{1,3}\.){3}[0-9]{1,3}|\[[0-9A-Fa-f:]+\])"
+    r":[0-9]{1,5}"
     r"(?![A-Za-z0-9])"
 )
 

--- a/ioc_finder/ioc_finder.py
+++ b/ioc_finder/ioc_finder.py
@@ -130,13 +130,23 @@ _CVE_CANDIDATE_RE = re.compile(
 _IMPHASH_CANDIDATE_RE = re.compile(r"(?:imphash|import hash)[^a-z0-9]*[a-f0-9]{32}(?![a-z0-9])")
 _AUTHENTIHASH_CANDIDATE_RE = re.compile(r"authentihash[^a-z0-9]*[a-f0-9]{64}(?![a-z0-9])")
 
-# URL marker: '://' (scheme present) or '.<tld>/' (scheme-less URL with a
-# path). The candidate span is built in Python by expanding from each
-# marker out to whitespace boundaries (see `_url_candidate_spans`). A pure
-# regex of the form `\S*<marker>\S*` would go quadratic on long
-# non-whitespace, non-URL runs (e.g. 10k bytes of base64) because the
-# leading `\S*` walks to the end and backtracks for each starting offset.
-_URL_MARKER_RE = re.compile(r"://|\.[A-Za-z][A-Za-z0-9-]*/")
+# URL marker: '://' (scheme present), '.<tld>[:port]/' (scheme-less URL with
+# a path), or an IPv4-shaped host + optional port + '/' (the scheme_less_url
+# grammar's url_authority accepts ipv4_address hosts, and the letter-after-dot
+# marker can never fire on one). The candidate span is built in Python by
+# expanding from each marker out to whitespace boundaries (see
+# `_url_candidate_spans`). A pure regex of the form `\S*<marker>\S*` would go
+# quadratic on long non-whitespace, non-URL runs (e.g. 10k bytes of base64)
+# because the leading `\S*` walks to the end and backtracks for each starting
+# offset; every alternative here is anchored (no leading unbounded
+# quantifier), so the scan stays linear. The markers are locators only — the
+# URL grammars remain the validators (e.g. `999.1.2.3/x` produces a candidate
+# span the grammar then rejects).
+_URL_MARKER_RE = re.compile(
+    r"://"
+    r"|\.[A-Za-z][A-Za-z0-9-]*(?::\d{1,5})?/"
+    r"|(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?/"
+)
 
 # MAC candidates: the three notations the grammar accepts —
 # `xx[:-]xx[:-]xx[:-]xx[:-]xx[:-]xx` (mixed colon/dash separators allowed)

--- a/ioc_finder/ioc_grammars.py
+++ b/ioc_finder/ioc_grammars.py
@@ -296,7 +296,11 @@ sha512 = (
 # A single regex rather than `Word("12") + Word(nums, exact=3)`: Word is
 # greedy and does not backtrack, so the old form ate every leading 1/2 digit
 # and failed on years whose digits are all 1s and 2s (e.g. "CVE-2121-12345").
-year = Regex(r"[12]\d{3}")
+# `[0-9]`, not `\d`: `re` is Unicode-aware while the `Word(nums)` it replaces
+# was ASCII-only, so `\d` here would accept non-ASCII year digits
+# ("CVE-2٠٢١-1234"). This grammar is the validator behind the deliberately
+# broad _CVE_CANDIDATE_RE, so it has to keep enforcing ASCII itself.
+year = Regex(r"[12][0-9]{3}")
 cve = (
     alphanum_word_start
     + Combine(
@@ -348,11 +352,12 @@ root_key = one_of(root_key_list)
 
 
 def hasMultipleConsecutiveSpaces(string):
-    """Return a truthy value if the given string contains multiple, consecutive
-    spaces anywhere (`re.search`, not the start-anchored `re.match` this used
-    previously — which silently accepted registry-key sections with an internal
-    double space, e.g. the "c  d" in `HKLM\\a\\b.c  d\\e`)."""
-    return re.search("  +", string)
+    """Return True if the given string contains multiple, consecutive spaces."""
+    # `re.search`, not `re.match`: the check has to see runs of spaces anywhere
+    # in the string, not only at its start. Start-anchoring silently accepted
+    # registry-key sections with an internal double space, letting surrounding
+    # prose ride along in the parsed path (e.g. the "c  d" in `HKLM\a\b.c  d\e`).
+    return bool(re.search("  +", string))
 
 
 def hasBothOrNeitherAngleBrackets(string):

--- a/ioc_finder/ioc_grammars.py
+++ b/ioc_finder/ioc_grammars.py
@@ -293,7 +293,10 @@ sha512 = (
     + alphanum_word_end
 )
 
-year = Word("12") + Word(nums, exact=3)
+# A single regex rather than `Word("12") + Word(nums, exact=3)`: Word is
+# greedy and does not backtrack, so the old form ate every leading 1/2 digit
+# and failed on years whose digits are all 1s and 2s (e.g. "CVE-2121-12345").
+year = Regex(r"[12]\d{3}")
 cve = (
     alphanum_word_start
     + Combine(
@@ -345,8 +348,11 @@ root_key = one_of(root_key_list)
 
 
 def hasMultipleConsecutiveSpaces(string):
-    """Return True if the given string has multiple, consecutive spaces."""
-    return re.match("  +", string)
+    """Return a truthy value if the given string contains multiple, consecutive
+    spaces anywhere (`re.search`, not the start-anchored `re.match` this used
+    previously — which silently accepted registry-key sections with an internal
+    double space, e.g. the "c  d" in `HKLM\\a\\b.c  d\\e`)."""
+    return re.search("  +", string)
 
 
 def hasBothOrNeitherAngleBrackets(string):

--- a/tests/find_iocs_cases/cves.py
+++ b/tests/find_iocs_cases/cves.py
@@ -6,5 +6,14 @@ CVE_DATA = [
         {"cves": ["CVE-2014-1000", "CVE-2014-1001", "CVE-1999-1002", "CVE-2999-1003", "CVE-1928-1004"]},
         {},
         id="cve_1",
-    )
+    ),
+    param(
+        # Years whose digits are all 1s and 2s: the old `Word("12") + Word(nums,
+        # exact=3)` year grammar was greedy and non-backtracking, so it consumed
+        # every leading 1/2 digit and failed on these.
+        "CVE-2121-12345 and CVE-2212-0001",
+        {"cves": ["CVE-2121-12345", "CVE-2212-0001"]},
+        {},
+        id="cve_year_of_all_ones_and_twos",
+    ),
 ]

--- a/tests/find_iocs_cases/registry_keys.py
+++ b/tests/find_iocs_cases/registry_keys.py
@@ -342,6 +342,16 @@ REGISTRY_DATA = [
         # start-anchored `re.match`, which missed internal double spaces and
         # let surrounding prose ride along in the parsed path (this text
         # previously yielded "HKLM\\SOFTWARE\\Microsoft\\Foo.exe  trailing junk\\More").
+        #
+        # NOTE: the expected value below records current behavior, not the
+        # ideal one — the ".exe" is dropped. `Word(alphanums + " ")` greedily
+        # eats "exe  trailing junk", the double-space condition then rejects
+        # it, and ZeroOrMore cannot retry a shorter match, so the whole
+        # extension segment is lost. The right answer is
+        # "HKLM\\SOFTWARE\\Microsoft\\Foo.exe" (which is what this text yields
+        # without the trailing junk). Rejecting the junk is the point of this
+        # case; the truncated extension is a separate, pre-existing
+        # non-backtracking-Word limitation.
         "HKLM\\SOFTWARE\\Microsoft\\Foo.exe  trailing junk\\More",
         {"registry_key_paths": ["HKLM\\SOFTWARE\\Microsoft\\Foo"]},
         {},

--- a/tests/find_iocs_cases/registry_keys.py
+++ b/tests/find_iocs_cases/registry_keys.py
@@ -336,4 +336,15 @@ REGISTRY_DATA = [
         {},
         id="registry_full_example",
     ),
+    param(
+        # A registry-key section containing an internal run of multiple spaces
+        # must not be absorbed into the path. The old double-space check used
+        # start-anchored `re.match`, which missed internal double spaces and
+        # let surrounding prose ride along in the parsed path (this text
+        # previously yielded "HKLM\\SOFTWARE\\Microsoft\\Foo.exe  trailing junk\\More").
+        "HKLM\\SOFTWARE\\Microsoft\\Foo.exe  trailing junk\\More",
+        {"registry_key_paths": ["HKLM\\SOFTWARE\\Microsoft\\Foo"]},
+        {},
+        id="registry_internal_double_space_rejected",
+    ),
 ]

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -625,30 +625,19 @@ def test_certificate_serial_number_issue_96():
     assert observables["mac_addresses"] == []
 
 
-def test_unicode_digits_are_not_parsed_as_ipv4s():
-    """The pure-Python IPv4 fast path must not accept non-ASCII digits. A
-    Unicode-aware `\\d` in the candidate regexes plus int()'s Unicode-digit
-    support would fabricate addresses (e.g. '١.٢.٣.٤' -> '1.2.3.4') that the
-    ASCII-only ipv4_address grammar never matched; the candidate regexes use
-    `[0-9]` to keep the old behavior."""
-    # Arabic-Indic and fullwidth digit quads: no IPv4s.
-    assert find_iocs("١.٢.٣.٤")["ipv4s"] == []
-    assert find_iocs("１.２.３.４")["ipv4s"] == []
-    # A Unicode digit hugging an ASCII quad rejects the whole match, mirroring
-    # the `\b` implied by the grammar's `Word(nums, as_keyword=True)` octets
-    # (a non-ASCII digit is a word character to `\b`).
-    assert find_iocs("٣3.2.3.4")["ipv4s"] == []
-    assert find_iocs("1.2.3.4٣")["ipv4s"] == []
-    # The old regex+grammar pipeline accepted these two ("1.2.3.4" /
-    # "1.2.3.4/8") because it ran the grammar on an isolated span and regex
-    # backtracking had already pushed the hugging Unicode digit outside it,
-    # hiding it from the grammar's `\b` — the same quad was rejected in the
-    # cases just above. The lookarounds apply that boundary rule to every
-    # hugging-digit case (see _IPV4_CANDIDATE_RE).
-    assert find_iocs("1.2.3.4٣.5")["ipv4s"] == []
-    assert find_iocs(".٣1.2.3.4/8")["ipv4_cidrs"] == []
-
-    # CIDRs: a Unicode digit in the bit range terminates the match exactly as
-    # the ASCII-only grammar did (the '1.2.3.4/1' prefix is still the IOC).
-    assert find_iocs("net 1.2.3.4/1٣")["ipv4_cidrs"] == ["1.2.3.4/1"]
-    assert find_iocs("١.٢.٣.٤/٨")["ipv4_cidrs"] == []
+def test_unicode_digits_are_not_parsed_as_socket_addresses_or_ipv6_cidrs():
+    """parse_socket_addresses and parse_ipv6_cidrs are pure-Python (no
+    pyparsing backstop), and their validators use str.isdigit()/int(), which
+    accept non-ASCII digits. The candidate regexes must therefore be ASCII
+    `[0-9]`, not `\\d`, or Unicode-digit inputs are emitted verbatim as IOCs
+    (e.g. '١.٢.٣.٤:80' or '2001:db8::/٣٢')."""
+    assert find_iocs("connect to ١.٢.٣.٤:80")["socket_addresses"] == []
+    assert find_iocs("1.2.3.4:٨0")["socket_addresses"] == []
+    assert find_iocs("2001:db8::/٣٢")["ipv6_cidrs"] == []
+    # A Unicode digit terminating the port/bit range truncates the match at
+    # the last ASCII digit, like any other non-alphanumeric terminator.
+    assert find_iocs("1.2.3.4:8٣")["socket_addresses"] == ["1.2.3.4:8"]
+    assert find_iocs("2001:db8::/3٢")["ipv6_cidrs"] == ["2001:db8::/3"]
+    # Sanity: plain ASCII forms still parse.
+    assert find_iocs("1.2.3.4:8080")["socket_addresses"] == ["1.2.3.4:8080"]
+    assert find_iocs("2001:db8::/32")["ipv6_cidrs"] == ["2001:db8::/32"]

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -641,3 +641,13 @@ def test_unicode_digits_are_not_parsed_as_socket_addresses_or_ipv6_cidrs():
     # Sanity: plain ASCII forms still parse.
     assert find_iocs("1.2.3.4:8080")["socket_addresses"] == ["1.2.3.4:8080"]
     assert find_iocs("2001:db8::/32")["ipv6_cidrs"] == ["2001:db8::/32"]
+
+
+def test_unicode_digits_are_not_parsed_as_cve_years():
+    """The `year` grammar is a `Regex`, and `re` is Unicode-aware where the
+    `Word(nums)` it replaced was ASCII-only. Both it and `_CVE_CANDIDATE_RE`
+    must spell their digits `[0-9]`, or a non-ASCII year is accepted."""
+    assert find_iocs("CVE-2٠٢١-1234")["cves"] == []
+    assert find_iocs("CVE-2021-١٢٣٤")["cves"] == []
+    # Sanity: plain ASCII forms still parse.
+    assert find_iocs("CVE-2021-1234")["cves"] == ["CVE-2021-1234"]

--- a/tests/test_parsing_functions.py
+++ b/tests/test_parsing_functions.py
@@ -23,6 +23,24 @@ def test_url_candidate_spans_skip_markers_inside_expanded_span():
     ]
 
 
+def test_url_candidate_spans_skip_bare_ipv4_cidrs():
+    """The IPv4 URL marker must not fire on bare CIDRs. Each candidate span it
+    produces costs ~750µs of grammar work, and for a CIDR that work is pure
+    waste — find_iocs discards the resulting "URL" in the issue-#91 removal
+    pass. Netblock feeds and firewall dumps are CIDR-dense by nature, so a
+    marker that fires on every one of them is a throughput cliff (2000 CIDRs:
+    0.006s with the exclusion, 2.0s without)."""
+    assert list(_url_candidate_spans("10.0.0.0/8 192.168.1.1/24 1.2.3.4/5")) == []
+
+    # ...but the exclusion is narrow: only one or two digits ending the
+    # whitespace-delimited token are skipped. Anything else still marks.
+    assert list(_url_candidate_spans("1.2.3.4/gate.php")) == [(0, "1.2.3.4/gate.php")]
+    assert list(_url_candidate_spans("1.2.3.4/80/x")) == [(0, "1.2.3.4/80/x")]
+    assert list(_url_candidate_spans("1.2.3.4/12?a=b")) == [(0, "1.2.3.4/12?a=b")]
+    assert list(_url_candidate_spans("1.2.3.4/123")) == [(0, "1.2.3.4/123")]
+    assert list(_url_candidate_spans("10.0.0.5:8443/c2/beacon")) == [(0, "10.0.0.5:8443/c2/beacon")]
+
+
 def test_parse_url_raises_on_unparseable_input():
     """`_parse_url` falls through all four URL grammars and raises."""
     with pytest.raises(ParseException, match="could not parse URL"):

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -5,6 +5,7 @@ from d8s_lists import iterables_have_same_items
 from pyparsing import ParseException
 
 from ioc_finder import find_iocs as _find_iocs
+from ioc_finder import parse_urls
 from ioc_finder.ioc_finder import SUPPORTED_IOC_TYPES, _parse_url, _remove_url_userinfo
 from ioc_finder.ioc_grammars import scheme_less_url
 
@@ -339,8 +340,22 @@ def test_scheme_less_url_with_ipv4_host_and_port_is_found():
 
 
 def test_ipv4_cidrs_still_not_found_as_urls_with_ipv4_url_marker():
-    """The IPv4 URL marker makes `1.1.1.1/0` a URL *candidate*; the CIDR
-    removal pass in find_iocs (issue #91) must still keep it out of urls."""
+    """The IPv4 URL marker must not turn CIDRs into URLs. It excludes the
+    bare-CIDR shape outright, so these never even become candidate spans; the
+    CIDR removal pass in find_iocs (issue #91) is the second line of defense."""
     result = find_iocs("1.1.1.1/0 and 10.0.0.0/8")
     assert result["urls"] == []
     assert iterables_have_same_items(result["ipv4_cidrs"], ["1.1.1.1/0", "10.0.0.0/8"])
+
+
+def test_bare_ipv4_cidrs_do_not_become_url_candidates():
+    """The bare-CIDR exclusion in `_URL_MARKER_RE` keeps netblock-dense text
+    off the grammar's slow path: a candidate span costs ~750µs of grammar work
+    that find_iocs then discards. `parse_urls` (which has no CIDR removal pass)
+    is the direct observation point."""
+    assert parse_urls("10.0.0.0/8") == []
+    assert parse_urls("192.168.1.1/24") == []
+    # ...but anything past the prefix-length digits is still a URL candidate.
+    assert parse_urls("1.2.3.4/80/x") == ["1.2.3.4/80/x"]
+    assert parse_urls("1.2.3.4/12?a=b") == ["1.2.3.4/12?a=b"]
+    assert parse_urls("1.2.3.4/123") == ["1.2.3.4/123"]

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -339,6 +339,18 @@ def test_scheme_less_url_with_ipv4_host_and_port_is_found():
     assert result["urls"] == ["10.0.0.5:8443/c2/beacon"]
 
 
+def test_scheme_less_url_port_is_not_capped_below_the_grammar():
+    """The marker must stay a superset of the grammar it gates. `port` is
+    `Word(":", nums, min=2)` — unbounded — so capping the marker's port at the
+    five digits a real TCP port needs would make these unreachable while the
+    scheme-*ful* spelling still parsed (the `://` marker never looks at the
+    port), i.e. the same authority would parse or not depending on whether a
+    scheme was present."""
+    assert parse_urls("example.com:123456/x") == ["example.com:123456/x"]
+    assert parse_urls("http://example.com:123456/x") == ["http://example.com:123456/x"]
+    assert parse_urls("1.2.3.4:123456/x") == ["1.2.3.4:123456/x"]
+
+
 def test_ipv4_cidrs_still_not_found_as_urls_with_ipv4_url_marker():
     """The IPv4 URL marker must not turn CIDRs into URLs. It excludes the
     bare-CIDR shape outright, so these never even become candidate spans; the

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -314,3 +314,33 @@ def test_remove_url_userinfo_works_for_scheme_ful_url():
         "http://userid:password@example.com/",
     )
     assert "userid:password@" not in stripped
+
+
+def test_scheme_less_url_with_port_is_found():
+    """A scheme-less URL with an explicit port must be found. The
+    `_URL_MARKER_RE` prefilter previously only recognized `://` and `.tld/`
+    markers, so `.tld:port/` spans were never handed to the (accepting)
+    scheme_less_url grammar."""
+    result = find_iocs("visit example.com:8080/admin now")
+    assert result["urls"] == ["example.com:8080/admin"]
+
+
+def test_scheme_less_url_with_ipv4_host_is_found():
+    """A scheme-less URL with an IPv4 host must be found. The `.tld/` marker
+    requires a letter after the dot, so `1.2.3.4/gate.php` spans were never
+    handed to the (accepting) scheme_less_url grammar."""
+    result = find_iocs("panel at 1.2.3.4/gate.php here")
+    assert result["urls"] == ["1.2.3.4/gate.php"]
+
+
+def test_scheme_less_url_with_ipv4_host_and_port_is_found():
+    result = find_iocs("callback to 10.0.0.5:8443/c2/beacon channel")
+    assert result["urls"] == ["10.0.0.5:8443/c2/beacon"]
+
+
+def test_ipv4_cidrs_still_not_found_as_urls_with_ipv4_url_marker():
+    """The IPv4 URL marker makes `1.1.1.1/0` a URL *candidate*; the CIDR
+    removal pass in find_iocs (issue #91) must still keep it out of urls."""
+    result = find_iocs("1.1.1.1/0 and 10.0.0.0/8")
+    assert result["urls"] == []
+    assert iterables_have_same_items(result["ipv4_cidrs"], ["1.1.1.1/0", "10.0.0.0/8"])

--- a/tests/test_utility_functions.py
+++ b/tests/test_utility_functions.py
@@ -24,3 +24,9 @@ def test_hasMultipleConsecutiveSpaces_1():
     assert not hasMultipleConsecutiveSpaces(" ")
     assert hasMultipleConsecutiveSpaces("  ")
     assert hasMultipleConsecutiveSpaces("   ")
+
+    # Runs of spaces anywhere in the string count, not only at its start.
+    assert hasMultipleConsecutiveSpaces("a  b")
+    assert hasMultipleConsecutiveSpaces("a b  c")
+    assert hasMultipleConsecutiveSpaces("Foo.exe  trailing junk")
+    assert not hasMultipleConsecutiveSpaces("a b c")


### PR DESCRIPTION
## Changes

- `_URL_MARKER_RE` now recognizes `.tld:port/` and IPv4-host markers, so scheme-less URLs like `example.com:8080/admin` and `1.2.3.4/gate.php` — which the `scheme_less_url` grammar already accepted — are no longer silently dropped by the candidate prefilter
- The IPv4 marker matches only the last two octets (`.3.4/`) so it leads with a literal `.` like the `.tld/` alternative beside it; leading with `[0-9]` widened `re`'s first-character prefilter set enough to defeat the skip and scanned the benchmark corpus 8x slower (1.21ms vs 0.15ms) for an identical set of hits. Markers only locate a span that is then expanded to its whitespace boundaries, so no coverage is lost
- The IPv4 marker also excludes the bare-CIDR shape (quad + `/` + one or two digits ending the token). Otherwise every CIDR in a netblock feed costs ~750µs of grammar work that `find_iocs` discards again in its CIDR removal pass; 2000 CIDRs through `parse_urls` went from 2.0s to 0.002s. Anything past the prefix-length digits (`/8.php`, `/12?a=b`, `/80/x`) still marks
- Replace the CVE `year` grammar `Word("12") + Word(nums, exact=3)` (greedy, non-backtracking — failed on years whose digits are all 1s and 2s, e.g. `CVE-2121-12345`) with `Regex(r"[12][0-9]{3}")`. Spelled `[0-9]` rather than `\d`: `re` is Unicode-aware where `Word(nums)` was ASCII-only, and this grammar is the validator behind a deliberately broad candidate regex, so `\d` would let `CVE-2٠٢١-1234` through. `_CVE_CANDIDATE_RE` matches
- Fix `hasMultipleConsecutiveSpaces` to use `re.search` instead of start-anchored `re.match`, so registry-key sections with an internal double space no longer absorb surrounding prose into the parsed path. It now returns a bool rather than a `Match`
- Reject non-ASCII digits in the socket-address and IPv6 CIDR candidate regexes (`[0-9]` instead of `\d`): these parsers validate in pure Python with `str.isdigit()`/`int()`, which accept Unicode digits, so inputs like `١.٢.٣.٤:80` or `2001:db8::/٣٢` were emitted verbatim as IOCs
- Add tests: scheme-less URL with port / IPv4 host / both, bare-CIDR marker exclusion asserted directly on `_url_candidate_spans`, all-1s/2s CVE years, non-ASCII CVE years, registry internal-double-space rejection, internal (non-start-anchored) double spaces as a unit test, Unicode-digit socket/CIDR rejection
- Add a CHANGELOG entry under `[Unreleased]`