### PR TITLE
Gate benchmarks against the PR's base commit instead of a checked-in baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,3 +72,79 @@ jobs:
       run: |
         uv run pytest
         uv run codecov
+
+  # Gate a PR against its own base commit instead of the checked-in
+  # .benchmarks/ baselines. Those are absolute numbers captured once on some
+  # other machine and refreshed only by hand, so they drift: as of #406 they
+  # claimed 6.57ms for test_parse_urls where main actually ran ~1.8ms, leaving
+  # ~3x of headroom in which a regression is invisible. A commit on that PR
+  # carrying a 2.3x parse_urls regression passed the baseline gate on all three
+  # OSes. Measuring the base commit in this same job, on this same runner,
+  # minutes apart, removes both the staleness and the cross-machine variance.
+  #
+  # This catches per-PR regressions; it cannot see cumulative drift (twenty PRs
+  # each 5% slower would all pass individually). The checked-in baselines
+  # compared in build_multi_os stay for that.
+  benchmark_regression:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        # The base commit is checked out below, so a shallow clone won't do.
+        fetch-depth: 0
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.14'
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v6
+    - name: Compare benchmarks against the base commit
+      run: |
+        set -euo pipefail
+
+        HEAD_SHA="$(git rev-parse HEAD)"
+        BASE_SHA="$(git rev-parse '${{ github.event.pull_request.base.sha }}')"
+        echo "comparing $BASE_SHA (base) -> $HEAD_SHA (head)"
+
+        # Both runs have to measure the same workload, so carry this PR's
+        # benchmark harness back onto the base commit's package source.
+        # Otherwise a PR that edits tests/benchmarks.py compares two different
+        # benchmarks and the percentages mean nothing.
+        mkdir -p /tmp/harness
+        cp tests/benchmarks.py /tmp/harness/benchmarks.py
+        cp -R tests/data /tmp/harness/data
+
+        git checkout --quiet --force --detach "$BASE_SHA"
+        mkdir -p tests/data
+        cp /tmp/harness/benchmarks.py tests/benchmarks.py
+        cp -R /tmp/harness/data/. tests/data/
+        uv sync --locked --group dev
+
+        # `-c .` mirrors how build_multi_os invokes the benchmarks: it makes
+        # pytest fail to resolve a config file, so the `-n auto --cov` addopts
+        # in pyproject.toml never apply. That matters — xdist disables
+        # pytest-benchmark outright, and coverage instrumentation would swamp
+        # the timings — so both runs here have to keep skipping them too.
+        #
+        # A PR whose harness cannot run against the base source at all (it
+        # benchmarks something the base commit does not have yet) is a skip,
+        # not a failure: there is no meaningful comparison to be made.
+        if ! uv run pytest -c "." --benchmark-storage=/tmp/bench \
+             --benchmark-save=base --benchmark-columns='mean,median,stddev' \
+             tests/benchmarks.py; then
+          echo "::warning::Could not benchmark base commit $BASE_SHA with this PR's harness; skipping the base-vs-head comparison."
+          exit 0
+        fi
+
+        # --force because the harness files copied in above are local edits.
+        git checkout --quiet --force --detach "$HEAD_SHA"
+        uv sync --locked --group dev
+
+        # Gate on median, not mean. pytest-benchmark's mean is badly
+        # outlier-sensitive on shared runners — one descheduled round can put
+        # the mean an order of magnitude above the median — so a mean gate
+        # tight enough to catch a real regression also flakes.
+        uv run pytest -c "." --benchmark-storage=/tmp/bench \
+          --benchmark-compare=0001 --benchmark-compare-fail='median:25%' \
+          --benchmark-columns='mean,median,stddev' tests/benchmarks.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,13 +128,12 @@ jobs:
         # the timings — so both runs here have to keep skipping them too.
         #
         # The storage path must stay *relative*. pytest-benchmark's
-        # storage.location does `path.relative_to(Path.cwd())`, and it is
-        # evaluated while formatting the "machine_info is different" warning —
-        # so an absolute path outside the workspace (e.g. /tmp/bench) turns
-        # that cosmetic warning into a pytest INTERNALERROR. That warning is
-        # expected to fire here: machine_info embeds py-cpuinfo's hz_actual,
-        # the CPU's current clock, which drifts between two runs seconds apart
-        # on a shared runner. It is harmless; the comparison still happens.
+        # storage.location does `path.relative_to(Path.cwd())`, so an absolute
+        # path outside the workspace (e.g. /tmp/bench) raises ValueError. That
+        # property is only read while formatting a "machine_info is different"
+        # warning, which makes the failure mode confusing: a cosmetic warning
+        # surfaces as a pytest INTERNALERROR with no obvious connection to the
+        # storage flag.
         #
         # A PR whose harness cannot run against the base source at all (it
         # benchmarks something the base commit does not have yet) is a skip,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,19 @@ jobs:
         # pytest-benchmark outright, and coverage instrumentation would swamp
         # the timings — so both runs here have to keep skipping them too.
         #
+        # The storage path must stay *relative*. pytest-benchmark's
+        # storage.location does `path.relative_to(Path.cwd())`, and it is
+        # evaluated while formatting the "machine_info is different" warning —
+        # so an absolute path outside the workspace (e.g. /tmp/bench) turns
+        # that cosmetic warning into a pytest INTERNALERROR. That warning is
+        # expected to fire here: machine_info embeds py-cpuinfo's hz_actual,
+        # the CPU's current clock, which drifts between two runs seconds apart
+        # on a shared runner. It is harmless; the comparison still happens.
+        #
         # A PR whose harness cannot run against the base source at all (it
         # benchmarks something the base commit does not have yet) is a skip,
         # not a failure: there is no meaningful comparison to be made.
-        if ! uv run pytest -c "." --benchmark-storage=/tmp/bench \
+        if ! uv run pytest -c "." --benchmark-storage=.bench-cmp \
              --benchmark-save=base --benchmark-columns='mean,median,stddev' \
              tests/benchmarks.py; then
           echo "::warning::Could not benchmark base commit $BASE_SHA with this PR's harness; skipping the base-vs-head comparison."
@@ -145,6 +154,6 @@ jobs:
         # outlier-sensitive on shared runners — one descheduled round can put
         # the mean an order of magnitude above the median — so a mean gate
         # tight enough to catch a real regression also flakes.
-        uv run pytest -c "." --benchmark-storage=/tmp/bench \
+        uv run pytest -c "." --benchmark-storage=.bench-cmp \
           --benchmark-compare=0001 --benchmark-compare-fail='median:25%' \
           --benchmark-columns='mean,median,stddev' tests/benchmarks.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,12 +137,29 @@ jobs:
         #
         # A PR whose harness cannot run against the base source at all (it
         # benchmarks something the base commit does not have yet) is a skip,
-        # not a failure: there is no meaningful comparison to be made.
-        if ! uv run pytest -c "." --benchmark-storage=.bench-cmp \
-             --benchmark-save=base --benchmark-columns='mean,median,stddev' \
-             tests/benchmarks.py; then
-          echo "::warning::Could not benchmark base commit $BASE_SHA with this PR's harness; skipping the base-vs-head comparison."
+        # not a failure: there is no meaningful comparison to be made. But the
+        # skip has to be narrow. Only two pytest exit codes mean "base is
+        # legitimately incompatible with this harness":
+        #   2  collection error — the harness imports a symbol the base lacks
+        #      (the exact "base too old for this PR's code" case)
+        #   5  no tests collected
+        # Every other nonzero exit is a real problem — a benchmark raising at
+        # runtime (1), a usage error (4), an INTERNALERROR (3), or a crash
+        # (segfault 139 / OOM 137) — and must fail the job. Treating those as a
+        # skip would make the gate report false-green, the worst failure mode
+        # for a regression check.
+        set +e
+        uv run pytest -c "." --benchmark-storage=.bench-cmp \
+          --benchmark-save=base --benchmark-columns='mean,median,stddev' \
+          tests/benchmarks.py
+        rc=$?
+        set -e
+        if [ "$rc" -eq 2 ] || [ "$rc" -eq 5 ]; then
+          echo "::warning::Base commit $BASE_SHA is incompatible with this PR's benchmark harness (pytest rc=$rc); skipping the base-vs-head comparison."
           exit 0
+        elif [ "$rc" -ne 0 ]; then
+          echo "::error::Benchmarking base commit $BASE_SHA failed unexpectedly (pytest rc=$rc)."
+          exit "$rc"
         fi
 
         # --force because the harness files copied in above are local edits.

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ Pipfile
 Pipfile.lock
 
 .DS_Store
+.bench-cmp/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+uv-managed project; Python 3.10+ required.
+
+- `uv sync --locked --group dev` — install deps (also `make init` / `make install`).
+- `uv run pytest` — run the suite. `pytest.ini_options` adds `-n auto` (xdist) and coverage with a high `--cov-fail-under` threshold (see `pyproject.toml`), so coverage regressions fail the run. Also `make test`.
+- `uv run pytest tests/test_ioc_finder.py::test_name` — single test (or `uv run pytest tests/test_ioc_finder.py` for one module).
+- `./docker/lint.sh` — the canonical lint step: `ruff check --fix`, `ruff format`, then (when `CONTEXT=ci`) asserts nothing changed, then `mypy`, then `ruff check`. CI runs this; `make lint` runs the ruff+mypy subset.
+- `uv run python scripts/find_hotspots.py` — profile which `parse_*` helper is slowest on the benchmark texts; run before and after tuning any parser. `tests/benchmarks.py` is the pytest-benchmark suite, gated two ways in CI: `benchmark_regression` benchmarks the PR's own base commit in the same job and fails on `median:25%` (this is the gate that catches a regression *you* introduced), while `build_multi_os` compares against the checked-in `.benchmarks/` baselines, which are absolute, per-OS, refreshed by hand, and therefore only good for spotting cumulative drift. Note that both invoke pytest as `pytest -c "."`, which deliberately fails to resolve a config file so the `-n auto --cov` addopts don't apply — xdist disables pytest-benchmark outright and coverage would swamp the timings.
+
+## Architecture
+
+The package finds indicators of compromise (URLs, IPs, hashes, domains, ATT&CK IDs, …) in free text.
+
+**`ioc_finder/ioc_finder.py`** — the main module.
+- `find_iocs(text, included_ioc_types=..., excluded_ioc_types=..., **options)` is the entry point. It calls `prepare_text()` (which runs `ioc_fanger.fang()` to normalize defanged IOCs first), then runs each requested `parse_*` helper, returning a dict keyed by IOC type. `SUPPORTED_IOC_TYPES` / `DEFAULT_IOC_TYPES` define the set. `cli_find_iocs` is the `ioc-finder` click CLI.
+- There is one `parse_*` helper per IOC type (`parse_urls`, `parse_domain_names`, `parse_md5s`, `parse_cves`, `parse_email_addresses`, the `parse_*_attack_*` family, …), all re-exported from `ioc_finder/__init__.py`.
+- **Order matters in `find_iocs`**: after a "containing" IOC is matched, its substructure is stripped from the working text via the `_remove_*` helpers (e.g. `_remove_url_domain_name`, `_remove_url_paths`, `_remove_xmpp_local_part`) so a URL's host isn't also reported as a bare domain.
+
+**`ioc_finder/ioc_grammars.py`** — the pyparsing grammars (`domain_name`, `complete_email_address`, `url`, `ipv6_address`, …) that are the *precise* validators. Some grammars are reused as sub-grammars (e.g. `domain_name` inside email/url/xmpp).
+
+**`ioc_finder/data.py`** — large static data tables (TLD set, ATT&CK technique/tactic/mitigation IDs, etc.) consumed by the grammars and parsers.
+
+**Performance pattern (important — see the long comments in `ioc_finder.py`):** running a pyparsing grammar at every offset is expensive, so `ioc_finder.py` defines cheap "candidate-span" regexes (`_DOMAIN_CANDIDATE_RE`, `_EMAIL_CANDIDATE_RE`, `_IPV4_CANDIDATE_RE`, `_MD5_CANDIDATE_RE`, `_CVE_CANDIDATE_RE`, `_URL_MARKER_RE`, …). `_scan_candidates` / `_scan_validated` / `_scan_url_candidates` locate plausible spans with the regex and then apply the grammar (or a pure-Python validator like `_is_valid_ipv6`) only there. **These regexes are deliberate supersets of what their grammar accepts and must stay in sync with the grammar's word-boundary rules** — the comments spell out which `ioc_grammars` construct each mirrors. Exceptions: the md5/sha1/sha256/sha512 candidate regexes are *exact* mirrors used as the sole validators (no pyparsing pass — see `_scan_hash_candidates`), and the IPv4/CIDR candidates are validated by pure-Python `_normalized_ipv4`; when editing any of these, keep the regex, the still-live grammar (md5/sha256 remain embedded in imphash/authentihash), and the Python validator in lockstep. Candidate regexes must use ASCII `[0-9]`, not `\d` — a Unicode-aware `\d` plus `int()` fabricates IOCs the grammars rejected. `parse_domain_names` consults `ioc_grammars.TLD_SET` directly so its fast path and the `domain_name` grammar can't disagree on what counts as a TLD.
+
+Grammars are module-level / shared; `tests/test_concurrency.py` guards against state leakage.
+
+## Conventions
+
+- Lint/format is enforced (`ruff`, `mypy`) — run `./docker/lint.sh` before pushing; CI fails if it would change files.
+- Tests are organized by area (`test_find_iocs.py`, `test_parsing_functions.py`, `test_urls.py`, `test_edge_cases.py`, `test_with_hypothesis.py`, …) plus `find_iocs_cases/` data-driven cases. Add tests with new IOC support.
+- `dependency_update_review_process.md` documents how Dependabot PRs are triaged (notably: bump the version *floor*, don't just widen the range). `ai_developer_guidelines.md` / `ai_manager_guidelines.md` / `ai_reviewer_guidelines.md` describe the multi-agent dev workflow.
+- When opening a PR, add a `Fixes #n` line to the body referencing the issue it closes.
+
+## Hooks
+
+`.claude/settings.json` configures a `PostToolUse` hook on `Write|Edit` that runs `./docker/lint.sh` whenever an `ioc_finder/*.py` or `tests/*.py` file is edited, and **blocks the turn (exit 2, lint output fed back) if it fails** — so a `ruff`/`mypy` failure has to be fixed before continuing.


### PR DESCRIPTION
## Changes

- Add a `benchmark_regression` job that benchmarks the PR's own base commit in the same job, on the same runner, and compares head against that — replacing reliance on the checked-in `.benchmarks/` baselines as the regression gate
- The checked-in baselines are absolute numbers captured once on another machine and refreshed by hand, so they drift. As of #406 they claimed 6.57ms for `test_parse_urls` where `main` actually ran ~1.8ms — ~3x of headroom in which a regression is invisible. `71489e0` on that PR carried a 2.3x `parse_urls` regression and **passed the baseline gate on all three OSes**; it was caught by hand, not by CI
- Carry the PR's benchmark harness back onto the base commit's source, so a PR that edits `tests/benchmarks.py` still compares like with like
- Skip the comparison with a warning (rather than failing the PR) *only* when the base commit is genuinely incompatible with this PR's benchmark harness — pytest exit 2 (collection error: the harness imports a symbol the base lacks) or 5 (no tests collected). Every other nonzero exit (a benchmark raising at runtime, a usage error, an INTERNALERROR, a crash) fails the job, so the gate can never report false-green
- Gate on `median:25%` rather than mean: pytest-benchmark's mean is badly outlier-sensitive on shared runners, so a mean gate tight enough to catch a real regression also flakes
- Keep `build_multi_os` comparing against the checked-in baselines — base-vs-head cannot see cumulative drift (twenty PRs each 5% slower would all pass individually), which is what those are actually good for
- Document both gates in `CLAUDE.md`, including that the `-c "."` in the benchmark invocation is load-bearing: it makes pytest fail to resolve a config file so the `-n auto --cov` addopts do not apply, and xdist would otherwise disable pytest-benchmark outright

Verified by replaying both directions against real commits: base `0abf154` → head `813d723` (current `main`) passes with medians within 1%, and base `0abf154` → head `71489e0` (the regression) fails at 4.4x.
